### PR TITLE
Added new Square copyright to UI

### DIFF
--- a/foundations_ui/src/js/components/common/CommonFooter.js
+++ b/foundations_ui/src/js/components/common/CommonFooter.js
@@ -19,17 +19,6 @@ class CommonFooter extends React.Component {
         <p>
           © 2020 Square, Inc. ATLAS, DESSA, the Dessa Logo, and others are trademarks of Square, Inc. All third party names and trademarks are properties of their respective owners and are used for identification purposes only.
         </p>
-        <p>
-          TensorFlow, the TensorFlow logo and any related marks are trademarks of Google Inc.
-          RAPIDS, the RAPIDS logo and any related marks are trademarks and/or registered trademarks of NVIDIA
-          Corporation.
-        </p>
-        <p>
-          Microsoft Azure, the Microsoft Azure logo and any related marks are trademarks and/or registered trademarks
-          of Microsoft Corporation.
-          Google Cloud Platform, the Google Cloud Platform logo and any related marks are trademarks and/or registered
-          trademarks of Google Inc.
-        </p>
       </div>
     );
   }

--- a/foundations_ui/src/scss/base/vars.scss
+++ b/foundations_ui/src/scss/base/vars.scss
@@ -3,7 +3,7 @@ $minimum-site-width: 860px;
 $minimum-site-height: 820px;
 $minimum-screen-width: 1280px;
 $minimum-job-header-screen-width: 675px;
-$footer-height: 80px;
+$footer-height: 40px;
 $header-height: 60px;
 
 // Common Vars


### PR DESCRIPTION
For ticket #1209

<img width="1792" alt="Screen Shot 2020-03-10 at 11 42 46 AM" src="https://user-images.githubusercontent.com/39602912/76330582-61ac1100-62c4-11ea-9db1-392bde9d7dd6.png">
