### PR TITLE
[AM] Replace f strings with format to prevent syntax error on python2

### DIFF
--- a/atlas_installer/atlas_installer.py
+++ b/atlas_installer/atlas_installer.py
@@ -393,11 +393,11 @@ def dump_all_config_files(advanced, use_specified_version):
                 "container": TENSORBOARD_SERVER_CONTAINER_NAME
             },
             "authentication_server": {
-                "image": f"{AUTHENTICATION_SERVER_IMAGE_NAME}:{AUTHENTICATION_SERVER_IMAGE_TAG}",
+                "image": "{}:{}".format(AUTHENTICATION_SERVER_IMAGE_NAME, AUTHENTICATION_SERVER_IMAGE_TAG),
                 "container": AUTHENTICATION_SERVER_CONTAINER_NAME
             },
             "authentication_proxy": {
-                "image": f"{AUTHENTICATION_PROXY_IMAGE_NAME}:{AUTHENTICATION_PROXY_IMAGE_TAG}",
+                "image": "{}:{}".format(AUTHENTICATION_PROXY_IMAGE_NAME, AUTHENTICATION_PROXY_IMAGE_TAG),
                 "container": AUTHENTICATION_PROXY_CONTAINER_NAME
             }
         }


### PR DESCRIPTION
Quick fix for people trying to use Python 2 to install atlas so that it fails gracefully.  Verified with Python 2, would be nice to test this.

From #124 