### PR TITLE
Fix rest-api breaking when metric_name has colons #96

### DIFF
--- a/atlas/foundations_rest_api/src/foundations_rest_api/v2beta/controllers/project_metrics_controller.py
+++ b/atlas/foundations_rest_api/src/foundations_rest_api/v2beta/controllers/project_metrics_controller.py
@@ -64,7 +64,7 @@ class ProjectMetricsController(object):
         from foundations_internal.fast_serializer import deserialize
 
         for metric_key, serialized_metric in self._serialized_project_metrics().items():
-            job_id, metric_name = metric_key.decode().split(":")
+            job_id, metric_name = metric_key.decode().split(":", 1)
             timestamp, value = deserialize(serialized_metric)
             yield {
                 "job_id": job_id,

--- a/atlas/foundations_rest_api/src/test/v2beta/controllers/test_project_metrics_controller.py
+++ b/atlas/foundations_rest_api/src/test/v2beta/controllers/test_project_metrics_controller.py
@@ -52,6 +52,20 @@ class TestProjectMetricsController(Spec):
 
         self.assertEqual(expected_output, self.controller.index().as_json())
 
+    def test_index_returns_timestamp_ordered_metrics_when_metric_name_has_colons(self):
+        self.controller.params = {'project_name': self.project_name}
+        self._log_metric(33, 'job13', 'metric77:007', 123.4)
+
+        expected_output = {
+            'all_metric_names': ['metric77:007'],
+            'metric_query': [{
+                'metric_name': 'metric77:007',
+                'values': [['job13', 123.4]]
+            }]
+        }
+
+        self.assertEqual(expected_output, self.controller.index().as_json())
+
     def test_index_returns_timestamp_ordered_metrics_different_metrics(self):
         self.controller.params = {'project_name': self.project_name}
         self._log_metric(321, 'job1', 'metric1', 432)


### PR DESCRIPTION
Straightforward change, added a unit test as well.

Additional Explanation: https://github.com/dessa-oss/atlas/issues/96#issuecomment-621452395