### PR TITLE
[Refactor FoundationsContext - PART13 - LAST] Rename foundations_context to foundations_job

### DIFF
--- a/atlas/aws_utils/src/integration/test_deploy_job.py
+++ b/atlas/aws_utils/src/integration/test_deploy_job.py
@@ -9,7 +9,7 @@ class TestDeployJob(unittest.TestCase):
         cleanup()
 
     def test_can_deploy_job_remotely(self):
-        from foundations.global_state import foundations_context
+        from foundations.global_state import foundations_job
         from os.path import isfile
         from integration.config import make_code_bucket
         from foundations_aws import AWSBucket
@@ -17,7 +17,7 @@ class TestDeployJob(unittest.TestCase):
         def method():
             pass
 
-        stage = foundations_context.pipeline().stage(method)
+        stage = foundations_job.pipeline().stage(method)
         deployment = self._make_deployment(stage)
         deployment.deploy()
 

--- a/atlas/foundations_contrib/src/foundations_contrib/archiving/save_artifact.py
+++ b/atlas/foundations_contrib/src/foundations_contrib/archiving/save_artifact.py
@@ -2,10 +2,10 @@
 import json
 
 def save_artifact(filepath, key=None):
-    from foundations_contrib.global_state import log_manager, current_foundations_context
+    from foundations_contrib.global_state import log_manager, current_foundations_job
 
     logger = log_manager.get_logger(__name__)
-    foundations_context = current_foundations_context()
+    foundations_context = current_foundations_job()
 
     if not foundations_context.is_in_running_job():
         logger.warning('Cannot save artifact outside of job.')

--- a/atlas/foundations_contrib/src/foundations_contrib/archiving/save_artifact.py
+++ b/atlas/foundations_contrib/src/foundations_contrib/archiving/save_artifact.py
@@ -5,12 +5,12 @@ def save_artifact(filepath, key=None):
     from foundations_contrib.global_state import log_manager, current_foundations_job
 
     logger = log_manager.get_logger(__name__)
-    foundations_context = current_foundations_job()
+    foundations_job = current_foundations_job()
 
-    if not foundations_context.is_in_running_job():
+    if not foundations_job.is_in_running_job():
         logger.warning('Cannot save artifact outside of job.')
     else:
-        job_id = foundations_context.job_id
+        job_id = foundations_job.job_id
 
         artifact_saver = _ArtifactSaver(logger, filepath, job_id, key)
         artifact_saver.save_artifact()

--- a/atlas/foundations_contrib/src/foundations_contrib/global_metric_logger.py
+++ b/atlas/foundations_contrib/src/foundations_contrib/global_metric_logger.py
@@ -27,8 +27,8 @@ class GlobalMetricLogger(object):
 
     @property
     def _foundations_context(self):
-        from foundations_contrib.global_state import current_foundations_context
-        return current_foundations_context()
+        from foundations_contrib.global_state import current_foundations_job
+        return current_foundations_job()
 
 def global_metric_logger_for_job():
     from foundations_contrib.global_state import message_router

--- a/atlas/foundations_contrib/src/foundations_contrib/global_metric_logger.py
+++ b/atlas/foundations_contrib/src/foundations_contrib/global_metric_logger.py
@@ -17,16 +17,16 @@ class GlobalMetricLogger(object):
             log_manager.set_foundations_not_running_warning_printed()
 
     def _is_job_running(self):
-        return self._foundations_context.is_in_running_job()
+        return self._foundations_job.is_in_running_job()
 
     def _project_name(self):
-        return self._foundations_context.project_name
+        return self._foundations_job.project_name
 
     def _job_id(self):
-        return self._foundations_context.job_id
+        return self._foundations_job.job_id
 
     @property
-    def _foundations_context(self):
+    def _foundations_job(self):
         from foundations_contrib.global_state import current_foundations_job
         return current_foundations_job()
 

--- a/atlas/foundations_contrib/src/foundations_contrib/global_state.py
+++ b/atlas/foundations_contrib/src/foundations_contrib/global_state.py
@@ -40,9 +40,9 @@ def _clear_state():
 
 
 def _create_foundations_context():
-    from foundations_internal.foundations_context import FoundationsContext
+    from foundations_internal.foundations_job import FoundationsJob
 
-    return FoundationsContext()
+    return FoundationsJob()
 
 
 foundations_context = _create_foundations_context()

--- a/atlas/foundations_contrib/src/foundations_contrib/global_state.py
+++ b/atlas/foundations_contrib/src/foundations_contrib/global_state.py
@@ -39,14 +39,14 @@ def _clear_state():
     redis_connection._redis_connection = None
 
 
-def _create_foundations_context():
+def _create_foundations_job():
     from foundations_internal.foundations_job import FoundationsJob
 
     return FoundationsJob()
 
 
-foundations_context = _create_foundations_context()
+foundations_context = _create_foundations_job()
 
 
-def current_foundations_context():
+def current_foundations_job():
     return foundations_context

--- a/atlas/foundations_contrib/src/foundations_contrib/global_state.py
+++ b/atlas/foundations_contrib/src/foundations_contrib/global_state.py
@@ -45,8 +45,8 @@ def _create_foundations_job():
     return FoundationsJob()
 
 
-foundations_context = _create_foundations_job()
+foundations_job = _create_foundations_job()
 
 
 def current_foundations_job():
-    return foundations_context
+    return foundations_job

--- a/atlas/foundations_contrib/src/foundations_contrib/set_job_resources.py
+++ b/atlas/foundations_contrib/src/foundations_contrib/set_job_resources.py
@@ -1,5 +1,5 @@
 
-from foundations_contrib.global_state import current_foundations_context
+from foundations_contrib.global_state import current_foundations_job
 from foundations_internal.job_resources import JobResources
 
 def set_job_resources(num_gpus=0, ram=None):
@@ -27,4 +27,4 @@ def set_job_resources(num_gpus=0, ram=None):
         raise ValueError('Invalid GPU quantity. Please provide a non-negative integer GPU quantity.')
 
     job_resources = JobResources(num_gpus, ram)
-    current_foundations_context().job_resources = job_resources
+    current_foundations_job().job_resources = job_resources

--- a/atlas/foundations_contrib/src/test/test_global_metric_logger.py
+++ b/atlas/foundations_contrib/src/test/test_global_metric_logger.py
@@ -4,7 +4,7 @@ from foundations_contrib.global_metric_logger import GlobalMetricLogger, global_
 
 class TestGlobalMetricLogger(Spec):
 
-    mock_current_foundations_context = let_patch_instance('foundations_contrib.global_state.current_foundations_context')
+    mock_current_foundations_job = let_patch_instance('foundations_contrib.global_state.current_foundations_job')
     mock_logger = let_mock()
 
     class MockMessageRouter(object):
@@ -67,16 +67,16 @@ class TestGlobalMetricLogger(Spec):
     def set_up(self):
         def mock_is_in_running_job():
             try:
-                return self.mock_current_foundations_context.job_id is not None
+                return self.mock_current_foundations_job.job_id is not None
             except ValueError:
                 return False
 
-        self.mock_current_foundations_context.is_in_running_job = mock_is_in_running_job
+        self.mock_current_foundations_job.is_in_running_job = mock_is_in_running_job
 
         self._message_router = self.MockMessageRouter()
         self._logger = GlobalMetricLogger(self._message_router)
 
-        self.mock_current_foundations_context.project_name = self.fake_project_name
+        self.mock_current_foundations_job.project_name = self.fake_project_name
         self._job_id = None
 
     @tear_down
@@ -85,34 +85,34 @@ class TestGlobalMetricLogger(Spec):
         log_manager.set_foundations_not_running_warning_printed(False)
 
     def test_log_metric_stores_metric(self):
-        self.mock_current_foundations_context.job_id = self.fake_job_id
+        self.mock_current_foundations_job.job_id = self.fake_job_id
         self._logger.log_metric(self.fake_metric_name, self.fake_metric_value)
         self.assertEqual([{'job_metrics': self.message}], self._logged_metrics())
 
     def test_log_metric_shows_warning_if_not_in_running_job(self):
-        self.mock_current_foundations_context.job_id = None
+        self.mock_current_foundations_job.job_id = None
         self._logger.log_metric(self.fake_metric_name, self.fake_metric_value)
         self.mock_logger.warning.assert_called_with('Script not run with Foundations.')
 
     def test_log_metric_shows_warning_only_once_if_not_in_running_job(self):
-        self.mock_current_foundations_context.job_id = None
+        self.mock_current_foundations_job.job_id = None
         self._logger.log_metric(self.fake_metric_name, self.fake_metric_value)
         self._logger.log_metric(self.fake_metric_name, self.fake_metric_value)
         self.mock_logger.warning.assert_called_once_with('Script not run with Foundations.')
 
     def test_log_metric_does_not_show_warning_if_in_running_job(self):
-        self.mock_current_foundations_context.job_id = self.fake_job_id
+        self.mock_current_foundations_job.job_id = self.fake_job_id
         self._logger.log_metric(self.fake_metric_name, self.fake_metric_value)
         self.mock_logger.warning.assert_not_called()
 
     def test_log_metric_can_log_multiple_messages(self):
-        self.mock_current_foundations_context.job_id = self.fake_job_id
+        self.mock_current_foundations_job.job_id = self.fake_job_id
         self._logger.log_metric(self.fake_metric_name, self.fake_metric_value)
         self._logger.log_metric(self.fake_metric_name_2, self.fake_metric_value_2)
         self.assertEqual([{'job_metrics': self.message}, {'job_metrics': self.message_2}], self._logged_metrics())
 
     def test_log_metric_does_not_log_anything_if_not_in_running_job(self):
-        self.mock_current_foundations_context.job_id = None
+        self.mock_current_foundations_job.job_id = None
         self._logger.log_metric(self.fake_metric_name, self.fake_metric_value)
         self.assertEqual([], self._logged_metrics())
 

--- a/atlas/foundations_contrib/src/test/test_job_deployer.py
+++ b/atlas/foundations_contrib/src/test/test_job_deployer.py
@@ -17,7 +17,7 @@ class TestJobDeployer(Spec):
         self.mock_log_manager.get_logger = mock_get_logger
 
         mock_simple_deploy = ConditionalReturn()
-        mock_simple_deploy.return_when(self.mock_deployment, self.fake_foundations_context, self.fake_job_name, self.fake_job_params)
+        mock_simple_deploy.return_when(self.mock_deployment, self.fake_foundations_job, self.fake_job_name, self.fake_job_params)
         self.mock_deployment_manager.simple_deploy = mock_simple_deploy
 
         self.mock_deployment.job_name.return_value = self.fake_job_name
@@ -27,13 +27,8 @@ class TestJobDeployer(Spec):
         return self.faker.uuid4()
 
     @let
-    def fake_pipeline_context(self):
-        return Mock()
-
-    @let
-    def fake_foundations_context(self):
+    def fake_foundations_job(self):
         result = Mock()
-        result.pipeline_context.return_value = self.fake_pipeline_context
         return result
 
     @let
@@ -41,15 +36,15 @@ class TestJobDeployer(Spec):
         return Mock()
 
     def test_job_deployer_logs_job_deploying_message(self):
-        deploy_job(self.fake_foundations_context, self.fake_job_name, self.fake_job_params)
+        deploy_job(self.fake_foundations_job, self.fake_job_name, self.fake_job_params)
         self.mock_logger.info.assert_called_with('Job submission started. Ctrl-C to cancel.')
     
     def test_job_deployer_returns_job_deployment_with_same_job_name_as_was_passed_in(self):
-        job_deployment = deploy_job(self.fake_foundations_context, self.fake_job_name, self.fake_job_params)
+        job_deployment = deploy_job(self.fake_foundations_job, self.fake_job_name, self.fake_job_params)
         self.assertEqual(self.fake_job_name, job_deployment.job_name())
 
     def test_job_deployer_returns_deployment_wrapper(self):
         from foundations_contrib.deployment_wrapper import DeploymentWrapper
 
-        job_deployment = deploy_job(self.fake_foundations_context, self.fake_job_name, self.fake_job_params)
+        job_deployment = deploy_job(self.fake_foundations_job, self.fake_job_name, self.fake_job_params)
         self.assertIsInstance(job_deployment, DeploymentWrapper)

--- a/atlas/foundations_contrib/src/test/test_set_job_resources.py
+++ b/atlas/foundations_contrib/src/test/test_set_job_resources.py
@@ -2,7 +2,7 @@
 from foundations_spec import *
 
 from foundations_contrib.set_job_resources import set_job_resources
-from foundations_contrib.global_state import current_foundations_context
+from foundations_contrib.global_state import current_foundations_job
 from foundations_internal.job_resources import JobResources
 
 class TestSetJobResources(Spec):
@@ -37,11 +37,11 @@ class TestSetJobResources(Spec):
 
     @tear_down
     def tear_down(self):
-        current_foundations_context().reset_job_resources()
+        current_foundations_job().reset_job_resources()
 
     def test_set_job_resources_sets_job_resources_object_in_current_foundations_context(self):
         set_job_resources(self.num_gpus, self.ram)
-        job_resources = current_foundations_context().job_resources
+        job_resources = current_foundations_job().job_resources
         self.assertEqual(self.job_resources, job_resources)
 
     def test_ram_set_less_than_or_equal_to_zero_throws_value_error(self):
@@ -55,14 +55,14 @@ class TestSetJobResources(Spec):
         with self.assertRaises(ValueError) as error_context:
             set_job_resources(self.num_gpus, self.invalid_ram)
 
-        job_resources = current_foundations_context().job_resources
+        job_resources = current_foundations_job().job_resources
         self.assertEqual(self.default_job_resources, job_resources)
 
     def test_ram_set_to_none_is_valid_configuration(self):
         set_job_resources(self.num_gpus, None)
 
         expected_job_resources = JobResources(num_gpus=self.num_gpus, ram=None)
-        job_resources = current_foundations_context().job_resources
+        job_resources = current_foundations_job().job_resources
         self.assertEqual(expected_job_resources, job_resources)
 
     def test_gpu_set_to_non_integer_value_throw_value_error(self):
@@ -76,7 +76,7 @@ class TestSetJobResources(Spec):
         with self.assertRaises(ValueError) as error_context:
             set_job_resources(self.non_integer_gpu, self.ram)
 
-        job_resources = current_foundations_context().job_resources
+        job_resources = current_foundations_job().job_resources
         self.assertEqual(self.default_job_resources, job_resources)
 
     def test_gpu_set_to_negative_value_throw_value_error(self):
@@ -90,16 +90,16 @@ class TestSetJobResources(Spec):
         with self.assertRaises(ValueError) as error_context:
             set_job_resources(self.negative_gpus, self.ram)
 
-        job_resources = current_foundations_context().job_resources
+        job_resources = current_foundations_job().job_resources
         self.assertEqual(self.default_job_resources, job_resources)
 
     def test_set_job_resources_ram_defaults_to_none(self):
         set_job_resources(num_gpus=self.num_gpus)
 
-        job_resources = current_foundations_context().job_resources
+        job_resources = current_foundations_job().job_resources
         self.assertEqual(JobResources(self.num_gpus, None), job_resources)
 
     def test_set_job_resources_num_gpus_defaults_to_zero(self):
         set_job_resources(ram=self.ram)
-        job_resources = current_foundations_context().job_resources
+        job_resources = current_foundations_job().job_resources
         self.assertEqual(JobResources(0, self.ram), job_resources)

--- a/atlas/foundations_contrib/src/test/test_set_job_resources.py
+++ b/atlas/foundations_contrib/src/test/test_set_job_resources.py
@@ -39,7 +39,7 @@ class TestSetJobResources(Spec):
     def tear_down(self):
         current_foundations_job().reset_job_resources()
 
-    def test_set_job_resources_sets_job_resources_object_in_current_foundations_context(self):
+    def test_set_job_resources_sets_job_resources_object_in_current_foundations_job(self):
         set_job_resources(self.num_gpus, self.ram)
         job_resources = current_foundations_job().job_resources
         self.assertEqual(self.job_resources, job_resources)

--- a/atlas/foundations_core_cli/src/foundations_core_cli/job_submission/deployment.py
+++ b/atlas/foundations_core_cli/src/foundations_core_cli/job_submission/deployment.py
@@ -7,7 +7,7 @@ def deploy(project_name, entrypoint, params):
 
     from foundations_contrib.job_deployer import deploy_job
     from foundations_contrib.global_state import (
-        current_foundations_context,
+        current_foundations_job,
         redis_connection,
         config_manager,
     )
@@ -15,7 +15,7 @@ def deploy(project_name, entrypoint, params):
     if project_name is None:
         project_name = path.basename(os.getcwd())
 
-    job = current_foundations_context()
+    job = current_foundations_job()
 
     job.project_name = project_name
     config_manager["run_script_environment"] = {

--- a/atlas/foundations_core_cli/src/foundations_core_cli/job_submission/submit_job.py
+++ b/atlas/foundations_core_cli/src/foundations_core_cli/job_submission/submit_job.py
@@ -54,9 +54,9 @@ def submit(arguments):
             job_resource_args['ram'] = arguments.ram
         set_job_resources(**job_resource_args)
 
-        from foundations.global_state import current_foundations_context
+        from foundations.global_state import current_foundations_job
         try:
-            cur_job_id = current_foundations_context().job_id
+            cur_job_id = current_foundations_job().job_id
         except ValueError:
             cur_job_id = None
 
@@ -73,6 +73,6 @@ def submit(arguments):
                 pass
 
         if cur_job_id is not None:
-            current_foundations_context().job_id = cur_job_id
+            current_foundations_job().job_id = cur_job_id
 
         return deployment

--- a/atlas/foundations_core_cli/src/test/job_submission/test_deployment.py
+++ b/atlas/foundations_core_cli/src/test/job_submission/test_deployment.py
@@ -20,8 +20,8 @@ class TestJobSubmissionDeployment(Spec):
 
     @let_now
     def foundations_context(self):
-        from foundations_internal.foundations_context import FoundationsContext
-        return self.patch('foundations_contrib.global_state.foundations_context', FoundationsContext())
+        from foundations_internal.foundations_job import FoundationsJob
+        return self.patch('foundations_contrib.global_state.foundations_context', FoundationsJob())
 
     @let_now
     def config_manager(self):

--- a/atlas/foundations_core_cli/src/test/job_submission/test_deployment.py
+++ b/atlas/foundations_core_cli/src/test/job_submission/test_deployment.py
@@ -19,9 +19,9 @@ class TestJobSubmissionDeployment(Spec):
         return f'{self.faker.uri_path()}/{self.project_name}'
 
     @let_now
-    def foundations_context(self):
+    def foundations_job(self):
         from foundations_internal.foundations_job import FoundationsJob
-        return self.patch('foundations_contrib.global_state.foundations_context', FoundationsJob())
+        return self.patch('foundations_contrib.global_state.foundations_job', FoundationsJob())
 
     @let_now
     def config_manager(self):
@@ -52,15 +52,15 @@ class TestJobSubmissionDeployment(Spec):
     def set_up(self):
         self.mock_os_getcwd.return_value = self.current_directory
         self.mock_open.return_when(self.mock_file, 'foundations_job_parameters.json', 'w+')
-        self.mock_deploy_job.return_when(self.mock_deployment, self.foundations_context, None, {})
+        self.mock_deploy_job.return_when(self.mock_deployment, self.foundations_job, None, {})
 
     def test_sets_project_name_from_parameter(self):
         deploy(self.project_name, self.entrypoint, self.params)
-        self.assertEqual(self.project_name, self.foundations_context.project_name)
+        self.assertEqual(self.project_name, self.foundations_job.project_name)
 
     def test_sets_project_name_from_current_directory_when_not_specified(self):
         deploy(None, self.entrypoint, self.params)
-        self.assertEqual(self.project_name, self.foundations_context.project_name)
+        self.assertEqual(self.project_name, self.foundations_job.project_name)
 
     def test_sets_run_script_environment_to_include_entrypoint(self):
         deploy(self.project_name, self.entrypoint, self.params)

--- a/atlas/foundations_core_cli/src/test/test_command_line_interface.py
+++ b/atlas/foundations_core_cli/src/test/test_command_line_interface.py
@@ -72,9 +72,9 @@ class TestCommandLineInterface(Spec):
 
     @let_now
     def current_foundations_context_instance(self):
-        from foundations_internal.foundations_context import FoundationsContext
+        from foundations_internal.foundations_job import FoundationsJob
 
-        foundations_context = FoundationsContext()
+        foundations_context = FoundationsJob()
         self.current_foundations_context.return_value = foundations_context
         return foundations_context
 

--- a/atlas/foundations_core_cli/src/test/test_command_line_interface.py
+++ b/atlas/foundations_core_cli/src/test/test_command_line_interface.py
@@ -29,7 +29,7 @@ class TestCommandLineInterface(Spec):
 
     mock_subprocess_run = let_patch_mock('subprocess.run')
     psutil_process_mock = let_patch_mock('psutil.Process')
-    current_foundations_context = let_patch_mock('foundations_contrib.global_state.current_foundations_context')
+    current_foundations_job = let_patch_mock('foundations_contrib.global_state.current_foundations_job')
     mock_message_router = let_patch_mock('foundations_contrib.global_state.message_router')
     print_mock = let_patch_mock('builtins.print')
     environment_fetcher_mock = let_patch_mock('foundations_core_cli.environment_fetcher.EnvironmentFetcher.get_all_environments')
@@ -41,11 +41,6 @@ class TestCommandLineInterface(Spec):
     @let_now
     def mock_environment(self):
         return self.patch('os.environ', {})
-
-    @let
-    def pipeline_context(self):
-        from foundations_internal.pipeline_context import PipelineContext
-        return PipelineContext()
 
     @let
     def level_1_subparsers_mock(self):
@@ -71,12 +66,12 @@ class TestCommandLineInterface(Spec):
         return PosixPath(path)
 
     @let_now
-    def current_foundations_context_instance(self):
+    def current_foundations_job_instance(self):
         from foundations_internal.foundations_job import FoundationsJob
 
-        foundations_context = FoundationsJob()
-        self.current_foundations_context.return_value = foundations_context
-        return foundations_context
+        foundations_job = FoundationsJob()
+        self.current_foundations_job.return_value = foundations_job
+        return foundations_job
 
     @let
     def command(self):

--- a/atlas/foundations_events/src/foundations_events/producers/jobs/complete_job.py
+++ b/atlas/foundations_events/src/foundations_events/producers/jobs/complete_job.py
@@ -7,9 +7,9 @@ class CompleteJob(object):
         pipeline_context {PipelineContext} -- The pipeline context associated with the job
     """
     
-    def __init__(self, message_router, foundations_context):
+    def __init__(self, message_router, foundations_job):
         self._message_router = message_router
-        self._foundations_context = foundations_context
+        self._foundations_job = foundations_job
 
     def push_message(self):
         """See above
@@ -18,7 +18,7 @@ class CompleteJob(object):
         self._message_router.push_message(
             'complete_job',
             {
-                'job_id': self._foundations_context.job_id,
-                'project_name': self._foundations_context.project_name
+                'job_id': self._foundations_job.job_id,
+                'project_name': self._foundations_job.project_name
             }
         )

--- a/atlas/foundations_events/src/foundations_events/producers/jobs/failed_job.py
+++ b/atlas/foundations_events/src/foundations_events/producers/jobs/failed_job.py
@@ -8,9 +8,9 @@ class FailedJob(object):
         error_information {dict} -- The error information provided by the StageContext of the failed stage
     """
     
-    def __init__(self, message_router, foundations_context, error_information):
+    def __init__(self, message_router, foundations_job, error_information):
         self._message_router = message_router
-        self._foundations_context = foundations_context
+        self._foundations_job = foundations_job
         self._error_information = error_information
 
     def push_message(self):
@@ -24,10 +24,10 @@ class FailedJob(object):
             'exception': str(self._error_information['exception']),
             'traceback': traceback.format_list(self._error_information['traceback'])
         }
-        job_id = self._foundations_context.job_id
+        job_id = self._foundations_job.job_id
         message = {
             'job_id': job_id,
             'error_information': error_information,
-            'project_name': self._foundations_context.provenance.project_name
+            'project_name': self._foundations_job.provenance.project_name
         }
         self._message_router.push_message('fail_job', message)

--- a/atlas/foundations_events/src/foundations_events/producers/jobs/queue_job.py
+++ b/atlas/foundations_events/src/foundations_events/producers/jobs/queue_job.py
@@ -8,9 +8,9 @@ class QueueJob(object):
         pipeline_context {PipelineContext} -- The pipeline context associated with the job
     """
 
-    def __init__(self, message_router, foundations_context):
+    def __init__(self, message_router, foundations_job):
         self._message_router = message_router
-        self._foundations_context = foundations_context
+        self._foundations_job = foundations_job
 
     def push_message(self):
         """See above
@@ -21,11 +21,11 @@ class QueueJob(object):
 
     def _message(self):
         message = {
-            'job_id': self._foundations_context.job_id,
-            'project_name': self._foundations_context.project_name,
-            'job_parameters': self._foundations_context.provenance.job_run_data,
-            'user_name': self._foundations_context.user_name,
-            'annotations': self._foundations_context.provenance.annotations,
+            'job_id': self._foundations_job.job_id,
+            'project_name': self._foundations_job.project_name,
+            'job_parameters': self._foundations_job.provenance.job_run_data,
+            'user_name': self._foundations_job.user_name,
+            'annotations': self._foundations_job.provenance.annotations,
         }
 
         return message

--- a/atlas/foundations_events/src/foundations_events/producers/jobs/run_job.py
+++ b/atlas/foundations_events/src/foundations_events/producers/jobs/run_job.py
@@ -7,17 +7,17 @@ class RunJob(object):
         pipeline_context {PipelineContext} -- The pipeline context associated with the job
     """
     
-    def __init__(self, message_router, foundations_context):
+    def __init__(self, message_router, foundations_job):
         self._message_router = message_router
-        self._foundations_context = foundations_context
+        self._foundations_job = foundations_job
 
     def push_message(self):
         """See above
         """
 
-        provenance = self._foundations_context.provenance
+        provenance = self._foundations_job.provenance
         message = {
-            'job_id': self._foundations_context.job_id,
+            'job_id': self._foundations_job.job_id,
             'project_name': provenance.project_name,
             'monitor_name': provenance.monitor_name or 'None'
         }

--- a/atlas/foundations_events/src/integration/test_consumers.py
+++ b/atlas/foundations_events/src/integration/test_consumers.py
@@ -7,14 +7,14 @@ class TestConsumers(unittest.TestCase):
     def setUp(self):
         from foundations_contrib.global_state import redis_connection
         from foundations_contrib.global_state import message_router
-        from foundations_internal.foundations_context import FoundationsContext
+        from foundations_internal.foundations_job import FoundationsJob
         import faker
 
         self._redis = redis_connection
         self._redis.flushall()
         self._faker = faker.Faker()
 
-        self._context = FoundationsContext()
+        self._context = FoundationsJob()
 
         self._project_name = self._str_random_uuid()
         self._context.provenance.project_name = self._project_name

--- a/atlas/foundations_events/src/test/producers/jobs/test_complete_job.py
+++ b/atlas/foundations_events/src/test/producers/jobs/test_complete_job.py
@@ -8,12 +8,12 @@ from foundations_events.producers.jobs.complete_job import CompleteJob
 class TestProducerCompleteJob(unittest.TestCase):
 
     def setUp(self):
-        from foundations_internal.foundations_context import FoundationsContext
+        from foundations_internal.foundations_job import FoundationsJob
 
         self.route_name = None
         self.message = None
 
-        self._foundations_context = FoundationsContext()
+        self._foundations_context = FoundationsJob()
         self._foundations_context.job_id = 'some_project'
         self._router = Mock()
         self._router.push_message.side_effect = self._push_message

--- a/atlas/foundations_events/src/test/producers/jobs/test_complete_job.py
+++ b/atlas/foundations_events/src/test/producers/jobs/test_complete_job.py
@@ -13,33 +13,33 @@ class TestProducerCompleteJob(unittest.TestCase):
         self.route_name = None
         self.message = None
 
-        self._foundations_context = FoundationsJob()
-        self._foundations_context.job_id = 'some_project'
+        self._foundations_job = FoundationsJob()
+        self._foundations_job.job_id = 'some_project'
         self._router = Mock()
         self._router.push_message.side_effect = self._push_message
-        self._producer = CompleteJob(self._router, self._foundations_context)
+        self._producer = CompleteJob(self._router, self._foundations_job)
 
     def test_push_message_sends_complete_job_message_to_correct_channel(self):
         self._producer.push_message()
         self.assertEqual('complete_job', self.route_name)
 
     def test_push_message_sends_complete_job_message_with_job_id(self):
-        self._foundations_context.job_id = 'my fantastic job'
+        self._foundations_job.job_id = 'my fantastic job'
         self._producer.push_message()
         self.assertDictContainsSubset({'job_id': 'my fantastic job'}, self.message)
 
     def test_push_message_sends_complete_job_message_with_job_id_different_job(self):
-        self._foundations_context.job_id = 'neural nets in space!'
+        self._foundations_job.job_id = 'neural nets in space!'
         self._producer.push_message()
         self.assertDictContainsSubset({'job_id': 'neural nets in space!'}, self.message)
 
     def test_push_message_sends_complete_job_message_with_project_name(self):
-        self._foundations_context.project_name = 'my fantastic job'
+        self._foundations_job.project_name = 'my fantastic job'
         self._producer.push_message()
         self.assertDictContainsSubset({'project_name': 'my fantastic job'}, self.message)
 
     def test_push_message_sends_complete_job_message_with_project_name_different_job(self):
-        self._foundations_context.project_name = 'neural nets in space!'
+        self._foundations_job.project_name = 'neural nets in space!'
         self._producer.push_message()
         self.assertDictContainsSubset({'project_name': 'neural nets in space!'}, self.message)
 

--- a/atlas/foundations_events/src/test/producers/jobs/test_failed_job.py
+++ b/atlas/foundations_events/src/test/producers/jobs/test_failed_job.py
@@ -8,12 +8,12 @@ from foundations_events.producers.jobs.failed_job import FailedJob
 class TestProducerFailedJob(unittest.TestCase):
 
     def setUp(self):
-        from foundations_internal.foundations_context import FoundationsContext
+        from foundations_internal.foundations_job import FoundationsJob
 
         self.route_name = None
         self.message = None
 
-        self._foundations_context = FoundationsContext()
+        self._foundations_context = FoundationsJob()
         self._foundations_context.job_id = 'some_project'
         self._router = Mock()
         self._router.push_message.side_effect = self._push_message

--- a/atlas/foundations_events/src/test/producers/jobs/test_failed_job.py
+++ b/atlas/foundations_events/src/test/producers/jobs/test_failed_job.py
@@ -13,36 +13,36 @@ class TestProducerFailedJob(unittest.TestCase):
         self.route_name = None
         self.message = None
 
-        self._foundations_context = FoundationsJob()
-        self._foundations_context.job_id = 'some_project'
+        self._foundations_job = FoundationsJob()
+        self._foundations_job.job_id = 'some_project'
         self._router = Mock()
         self._router.push_message.side_effect = self._push_message
         self._error_information = {'type': None,
                                    'exception': None, 'traceback': []}
         self._producer = FailedJob(
-            self._router, self._foundations_context, self._error_information)
+            self._router, self._foundations_job, self._error_information)
 
     def test_push_message_sends_fail_job_message_to_correct_channel(self):
         self._producer.push_message()
         self.assertEqual('fail_job', self.route_name)
 
     def test_push_message_sends_fail_job_message_with_job_id(self):
-        self._foundations_context.job_id = 'my fantastic job'
+        self._foundations_job.job_id = 'my fantastic job'
         self._producer.push_message()
         self.assertEqual('my fantastic job', self.message['job_id'])
 
     def test_push_message_sends_fail_job_message_with_job_id_different_job(self):
-        self._foundations_context.job_id = 'neural nets in space!'
+        self._foundations_job.job_id = 'neural nets in space!'
         self._producer.push_message()
         self.assertEqual('neural nets in space!', self.message['job_id'])
 
     def test_push_message_sends_complete_job_message_with_project_name(self):
-        self._foundations_context.project_name = 'my fantastic job'
+        self._foundations_job.project_name = 'my fantastic job'
         self._producer.push_message()
         self.assertDictContainsSubset({'project_name': 'my fantastic job'}, self.message)
 
     def test_push_message_sends_complete_job_message_with_project_name_different_job(self):
-        self._foundations_context.project_name = 'neural nets in space!'
+        self._foundations_job.project_name = 'neural nets in space!'
         self._producer.push_message()
         self.assertDictContainsSubset({'project_name': 'neural nets in space!'}, self.message)
 

--- a/atlas/foundations_events/src/test/producers/jobs/test_queue_job.py
+++ b/atlas/foundations_events/src/test/producers/jobs/test_queue_job.py
@@ -8,13 +8,13 @@ from foundations_events.producers.jobs.queue_job import QueueJob
 class TestProducerQueueJob(unittest.TestCase):
 
     def setUp(self):
-        from foundations_internal.foundations_context import FoundationsContext
+        from foundations_internal.foundations_job import FoundationsJob
         from faker import Faker
 
         self.route_name = None
         self.message = None
 
-        self._foundations_context = FoundationsContext()
+        self._foundations_context = FoundationsJob()
         self._foundations_context.job_id = 'some_project'
         self._router = Mock()
         self._router.push_message.side_effect = self._push_message

--- a/atlas/foundations_events/src/test/producers/jobs/test_queue_job.py
+++ b/atlas/foundations_events/src/test/producers/jobs/test_queue_job.py
@@ -14,11 +14,11 @@ class TestProducerQueueJob(unittest.TestCase):
         self.route_name = None
         self.message = None
 
-        self._foundations_context = FoundationsJob()
-        self._foundations_context.job_id = 'some_project'
+        self._foundations_job = FoundationsJob()
+        self._foundations_job.job_id = 'some_project'
         self._router = Mock()
         self._router.push_message.side_effect = self._push_message
-        self._producer = QueueJob(self._router, self._foundations_context)
+        self._producer = QueueJob(self._router, self._foundations_job)
         self._faker = Faker()
 
     def test_push_message_sends_queue_job_message_to_correct_channel(self):
@@ -27,31 +27,31 @@ class TestProducerQueueJob(unittest.TestCase):
 
     def test_push_message_sends_queue_job_message_with_job_id(self):
         job_id = self._make_string_uuid()
-        self._foundations_context.job_id = job_id
+        self._foundations_job.job_id = job_id
         self._producer.push_message()
         self.assertEqual(job_id, self.message['job_id'])
 
     def test_push_message_send_queue_job_message_with_project_name(self):
         project_name = self._faker.name()
-        self._foundations_context.project_name = project_name
+        self._foundations_job.project_name = project_name
         self._producer.push_message()
         self.assertEqual(project_name, self.message['project_name'])
 
     def test_push_message_send_queue_job_message_with_job_parameters(self):
         run_data = self._make_run_data()
-        self._foundations_context.provenance.job_run_data = run_data
+        self._foundations_job.provenance.job_run_data = run_data
         self._producer.push_message()
         self.assertEqual(run_data, self.message['job_parameters'])
 
     def test_push_message_send_queue_job_message_with_user_name(self):
         user_name = self._faker.name()
-        self._foundations_context.user_name = user_name
+        self._foundations_job.user_name = user_name
         self._producer.push_message()
         self.assertEqual(user_name, self.message['user_name'])
 
     def test_push_message_send_queue_job_message_with_annotations(self):
         annotations = self._faker.name()
-        self._foundations_context.provenance.annotations = annotations
+        self._foundations_job.provenance.annotations = annotations
         self._producer.push_message()
         self.assertEqual(annotations, self.message['annotations'])
 

--- a/atlas/foundations_events/src/test/producers/jobs/test_run_job.py
+++ b/atlas/foundations_events/src/test/producers/jobs/test_run_job.py
@@ -8,12 +8,12 @@ from foundations_events.producers.jobs.run_job import RunJob
 class TestProducerRunJob(unittest.TestCase):
 
     def setUp(self):
-        from foundations_internal.foundations_context import FoundationsContext
+        from foundations_internal.foundations_job import FoundationsJob
 
         self.route_name = None
         self.message = None
 
-        self._foundations_context = FoundationsContext()
+        self._foundations_context = FoundationsJob()
         self._foundations_context.job_id = 'some_project'
         self._router = Mock()
         self._router.push_message.side_effect = self._push_message

--- a/atlas/foundations_events/src/test/producers/jobs/test_run_job.py
+++ b/atlas/foundations_events/src/test/producers/jobs/test_run_job.py
@@ -13,27 +13,27 @@ class TestProducerRunJob(unittest.TestCase):
         self.route_name = None
         self.message = None
 
-        self._foundations_context = FoundationsJob()
-        self._foundations_context.job_id = 'some_project'
+        self._foundations_job = FoundationsJob()
+        self._foundations_job.job_id = 'some_project'
         self._router = Mock()
         self._router.push_message.side_effect = self._push_message
-        self._producer = RunJob(self._router, self._foundations_context)
+        self._producer = RunJob(self._router, self._foundations_job)
 
     def test_push_message_sends_run_job_message_to_correct_channel(self):
         self._producer.push_message()
         self.assertEqual('run_job', self.route_name)
 
     def test_push_message_sends_run_job_message_with_job_id(self):
-        self._foundations_context.job_id = 'my fantastic job'
-        self._foundations_context.project_name = 'this project'
+        self._foundations_job.job_id = 'my fantastic job'
+        self._foundations_job.project_name = 'this project'
         self._producer.push_message()
         self.assertEqual({'job_id': 'my fantastic job',
                           'project_name': 'this project',
                           'monitor_name': 'None'}, self.message)
 
     def test_push_message_sends_run_job_message_with_job_id_different_job_different_project(self):
-        self._foundations_context.job_id = 'neural nets in space!'
-        self._foundations_context.project_name = 'that project'
+        self._foundations_job.job_id = 'neural nets in space!'
+        self._foundations_job.project_name = 'that project'
         self._producer.push_message()
         self.assertEqual({'job_id': 'neural nets in space!',
                           'project_name': 'that project',

--- a/atlas/foundations_internal/src/foundations_internal/deployment_manager.py
+++ b/atlas/foundations_internal/src/foundations_internal/deployment_manager.py
@@ -17,13 +17,13 @@ class DeploymentManager(object):
 
     def deploy(self, deployment_config, job_name, job):
         from foundations import log_manager
-        from foundations.global_state import current_foundations_context
+        from foundations.global_state import current_foundations_job
 
         logger = log_manager.get_logger(__name__)
 
         deployment = self._create_deployment(job_name, job)
         deployment.config().update(deployment_config)
-        project_name = current_foundations_context().project_name
+        project_name = current_foundations_job().project_name
 
         deployment.deploy()
         logger.info("Job submitted with ID '{}' in project '{}'.".format(job_name, project_name))

--- a/atlas/foundations_internal/src/foundations_internal/deployment_manager.py
+++ b/atlas/foundations_internal/src/foundations_internal/deployment_manager.py
@@ -30,11 +30,11 @@ class DeploymentManager(object):
 
         return deployment
 
-    def _record_project(self, foundations_context):
+    def _record_project(self, foundations_job):
         constructor, constructor_args, constructor_kwargs = self.project_listing_constructor_and_args_and_kwargs()
         listing = constructor(*constructor_args, **constructor_kwargs)
         listing.track_pipeline(
-            foundations_context.project_name)
+            foundations_job.project_name)
 
     def _create_deployment(self, job_name, job):
         from foundations_contrib.job_source_bundle import JobSourceBundle

--- a/atlas/foundations_internal/src/foundations_internal/foundations_job.py
+++ b/atlas/foundations_internal/src/foundations_internal/foundations_job.py
@@ -1,7 +1,7 @@
 from foundations_internal.provenance import Provenance
 
 
-class FoundationsContext(object):
+class FoundationsJob(object):
 
     def __init__(self):
         self._job_resources = self._default_job_resources()

--- a/atlas/foundations_internal/src/integration/config.py
+++ b/atlas/foundations_internal/src/integration/config.py
@@ -1,6 +1,6 @@
 
 def _configure():
-    from foundations_contrib.global_state import current_foundations_context
-    current_foundations_context().job_id = 'integration-test-job'
+    from foundations_contrib.global_state import current_foundations_job
+    current_foundations_job().job_id = 'integration-test-job'
 
 _configure()

--- a/atlas/foundations_internal/src/test/__init__.py
+++ b/atlas/foundations_internal/src/test/__init__.py
@@ -1,6 +1,6 @@
 from test.test_provenance import TestProvenance
 from test.test_deployment_manager import TestDeploymentManager
-from test.test_foundations_context import TestFoundationsContext
+from test.test_foundations_job import TestFoundationsJob
 from test.test_module_manager import TestModuleManager
 from test.test_foundations_serializer import TestFoundationsSerializer
 from test.test_job_resources import TestJobResources

--- a/atlas/foundations_internal/src/test/test_deployment_manager.py
+++ b/atlas/foundations_internal/src/test/test_deployment_manager.py
@@ -30,7 +30,7 @@ class TestDeploymentManager(unittest.TestCase):
     def setUp(self):
         from foundations_contrib.config_manager import ConfigManager
         from foundations_internal.deployment_manager import DeploymentManager
-        from foundations_internal.foundations_context import FoundationsContext
+        from foundations_internal.foundations_job import FoundationsJob
 
         self._listing = self.MockListing()
 
@@ -45,7 +45,7 @@ class TestDeploymentManager(unittest.TestCase):
 
         self._deployment_manager = DeploymentManager(self._config)
 
-        self._foundations_context = FoundationsContext()
+        self._foundations_context = FoundationsJob()
 
     def test_deploy_persisted_project_name(self):
         self._foundations_context.project_name = "my project"

--- a/atlas/foundations_internal/src/test/test_deployment_manager.py
+++ b/atlas/foundations_internal/src/test/test_deployment_manager.py
@@ -45,17 +45,17 @@ class TestDeploymentManager(unittest.TestCase):
 
         self._deployment_manager = DeploymentManager(self._config)
 
-        self._foundations_context = FoundationsJob()
+        self._foundations_job = FoundationsJob()
 
     def test_deploy_persisted_project_name(self):
-        self._foundations_context.project_name = "my project"
-        self._deployment_manager.simple_deploy(self._foundations_context, "", {})
+        self._foundations_job.project_name = "my project"
+        self._deployment_manager.simple_deploy(self._foundations_job, "", {})
 
         self.assertEqual("my project", self._listing.value)
 
     def test_deploy_persisted_project_name_different_name(self):
-        self._foundations_context.project_name = "project potato launcher"
-        self._deployment_manager.simple_deploy(self._foundations_context, "", {})
+        self._foundations_job.project_name = "project potato launcher"
+        self._deployment_manager.simple_deploy(self._foundations_job, "", {})
 
         self.assertEqual("project potato launcher", self._listing.value)
 
@@ -69,8 +69,8 @@ class TestDeploymentManager(unittest.TestCase):
 
         del self._config.config()["project_listing_implementation"]
 
-        self._foundations_context.project_name = "my project"
-        self._deployment_manager.simple_deploy(self._foundations_context, "", {})
+        self._foundations_job.project_name = "my project"
+        self._deployment_manager.simple_deploy(self._foundations_job, "", {})
 
         self.assertEqual("my project", self._listing.value)
 

--- a/atlas/foundations_internal/src/test/test_foundations_context.py
+++ b/atlas/foundations_internal/src/test/test_foundations_context.py
@@ -2,7 +2,7 @@
 import unittest
 
 from foundations_spec import *
-from foundations_internal.foundations_context import FoundationsContext
+from foundations_internal.foundations_job import FoundationsJob
 from foundations_internal.job_resources import JobResources
 
 class TestFoundationsContext(Spec):
@@ -24,7 +24,7 @@ class TestFoundationsContext(Spec):
         return self.faker.word()
 
     def setUp(self):
-        self._context = FoundationsContext()
+        self._context = FoundationsJob()
 
     def test_set_project_name_sets_provenance_project_name(self):
         self._context.project_name = 'my project'

--- a/atlas/foundations_internal/src/test/test_foundations_context.py
+++ b/atlas/foundations_internal/src/test/test_foundations_context.py
@@ -64,9 +64,9 @@ class TestFoundationsContext(Spec):
         self._context.project_name = self.fake_project_name
         self.assertEqual(self.fake_project_name, self._context.project_name)
 
-    def test_is_in_running_job_returns_true_if_pipeline_context_has_job_id(self):
+    def test_is_in_running_job_returns_true_if_foundations_context_has_job_id(self):
         self._context.job_id = self.job_id
         self.assertTrue(self._context.is_in_running_job())
 
-    def test_is_in_running_job_returns_false_if_pipeline_context_does_not_have_job_id(self):
+    def test_is_in_running_job_returns_false_if_foundations_context_does_not_have_job_id(self):
         self.assertFalse(self._context.is_in_running_job())

--- a/atlas/foundations_internal/src/test/test_foundations_job.py
+++ b/atlas/foundations_internal/src/test/test_foundations_job.py
@@ -5,7 +5,7 @@ from foundations_spec import *
 from foundations_internal.foundations_job import FoundationsJob
 from foundations_internal.job_resources import JobResources
 
-class TestFoundationsContext(Spec):
+class TestFoundationsJob(Spec):
 
     @let
     def job_id(self):
@@ -64,9 +64,9 @@ class TestFoundationsContext(Spec):
         self._context.project_name = self.fake_project_name
         self.assertEqual(self.fake_project_name, self._context.project_name)
 
-    def test_is_in_running_job_returns_true_if_foundations_context_has_job_id(self):
+    def test_is_in_running_job_returns_true_if_foundations_job_has_job_id(self):
         self._context.job_id = self.job_id
         self.assertTrue(self._context.is_in_running_job())
 
-    def test_is_in_running_job_returns_false_if_foundations_context_does_not_have_job_id(self):
+    def test_is_in_running_job_returns_false_if_foundations_job_does_not_have_job_id(self):
         self.assertFalse(self._context.is_in_running_job())

--- a/atlas/foundations_local_docker_scheduler_plugin/src/foundations_local_docker_scheduler_plugin/job_deployment.py
+++ b/atlas/foundations_local_docker_scheduler_plugin/src/foundations_local_docker_scheduler_plugin/job_deployment.py
@@ -241,11 +241,11 @@ class JobDeployment(object):
             return False
 
     def _job_resources(self):
-        from foundations_contrib.global_state import current_foundations_context
-        return current_foundations_context().job_resources
+        from foundations_contrib.global_state import current_foundations_job
+        return current_foundations_job().job_resources
 
     def _create_job_spec(self, job_mount_path, working_dir_root_path, job_results_root_path, container_config_root_path, job_id, project_name, username, worker_container_overrides):
-        from foundations_contrib.global_state import current_foundations_context
+        from foundations_contrib.global_state import current_foundations_job
 
         worker_container = {
 
@@ -295,11 +295,11 @@ class JobDeployment(object):
             "network": "foundations-atlas"
         }
 
-        if current_foundations_context().job_resources.ram is not None:
-            worker_container['mem_limit'] = int(current_foundations_context().job_resources.ram)
+        if current_foundations_job().job_resources.ram is not None:
+            worker_container['mem_limit'] = int(current_foundations_job().job_resources.ram)
 
-        if (current_foundations_context().job_resources.num_gpus is not None
-                and current_foundations_context().job_resources.num_gpus > 0):
+        if (current_foundations_job().job_resources.num_gpus is not None
+                and current_foundations_job().job_resources.num_gpus > 0):
             worker_container['image'] = 'us.gcr.io/dessa-atlas/worker-gpu:latest'
             worker_container['runtime'] = 'nvidia'
 

--- a/atlas/foundations_local_docker_scheduler_plugin/src/foundations_local_docker_scheduler_plugin/job_deployment.py
+++ b/atlas/foundations_local_docker_scheduler_plugin/src/foundations_local_docker_scheduler_plugin/job_deployment.py
@@ -332,8 +332,8 @@ class JobDeployment(object):
         return worker_container
 
     def _create_gpu_spec(self):
-        from foundations_contrib.global_state import foundations_context
-        resources = foundations_context.job_resources
+        from foundations_contrib.global_state import foundations_job
+        resources = foundations_job.job_resources
         gpu_spec = {
             "num_gpus": resources.num_gpus
         }

--- a/atlas/foundations_rest_api/src/acceptance/cleanup.py
+++ b/atlas/foundations_rest_api/src/acceptance/cleanup.py
@@ -5,7 +5,7 @@ def cleanup():
     from glob import glob
     from foundations_rest_api.global_state import redis_connection
     import foundations_contrib.global_state
-    from foundations_internal.foundations_context import FoundationsContext
+    from foundations_internal.foundations_job import FoundationsJob
 
     tmp_dir = getcwd() + '/tmp'
     if isdir(tmp_dir):
@@ -16,4 +16,4 @@ def cleanup():
 
     redis_connection.flushall()
 
-    foundations_contrib.global_state.foundations_context = FoundationsContext()
+    foundations_contrib.global_state.foundations_job = FoundationsJob()

--- a/atlas/foundations_rest_api/src/acceptance/v2beta/jobs_tests_helper_mixin_v2.py
+++ b/atlas/foundations_rest_api/src/acceptance/v2beta/jobs_tests_helper_mixin_v2.py
@@ -70,11 +70,11 @@ class JobsTestsHelperMixinV2(object):
 
     @classmethod
     def _set_tags(klass, job_name, tags):
-        from foundations_contrib.global_state import current_foundations_context
+        from foundations_contrib.global_state import current_foundations_job
         from foundations import set_tag
 
-        foundations_context = current_foundations_context()
-        foundations_context.job_id = job_name
+        foudnations_context = current_foundations_job()
+        foudnations_context.job_id = job_name
 
         if tags is not None:
             for key, value in tags.items():

--- a/atlas/foundations_rest_api/src/acceptance/v2beta/jobs_tests_helper_mixin_v2.py
+++ b/atlas/foundations_rest_api/src/acceptance/v2beta/jobs_tests_helper_mixin_v2.py
@@ -9,15 +9,15 @@ class JobsTestsHelperMixinV2(object):
     @classmethod
     def setUpClass(klass):
         from foundations_contrib.global_state import message_router
-        from foundations_internal.foundations_context import FoundationsContext
+        from foundations_internal.foundations_job import FoundationsJob
 
         klass._message_router = message_router
-        klass._foundations_context = FoundationsContext()
+        klass._foundations_job = FoundationsJob()
 
     @classmethod
     def _set_project_name(klass, project_name):
         klass._project_name = project_name
-        klass._foundations_context.project_name = klass._project_name
+        klass._foundations_job.project_name = klass._project_name
 
     @staticmethod
     def _str_random_uuid():
@@ -41,43 +41,43 @@ class JobsTestsHelperMixinV2(object):
 
     @classmethod
     def _make_completed_job(klass, job_name, user, tags=None, start_timestamp=None, end_timestamp=None, **kwargs):
-        klass._foundations_context.job_id = job_name
-        klass._foundations_context.user_name = user
-        klass._foundations_context.provenance.job_run_data = kwargs
-        QueueJob(klass._message_router, klass._foundations_context).push_message()
+        klass._foundations_job.job_id = job_name
+        klass._foundations_job.user_name = user
+        klass._foundations_job.provenance.job_run_data = kwargs
+        QueueJob(klass._message_router, klass._foundations_job).push_message()
         klass._fake_start_time(start_timestamp)
-        RunJob(klass._message_router, klass._foundations_context).push_message()
+        RunJob(klass._message_router, klass._foundations_job).push_message()
         klass._set_tags(job_name, tags)
         klass._fake_end_time(end_timestamp)
-        CompleteJob(klass._message_router, klass._foundations_context).push_message()
+        CompleteJob(klass._message_router, klass._foundations_job).push_message()
         klass._restore_time(start_timestamp, end_timestamp)
 
     @classmethod
     def _make_running_job(klass, job_name, user, tags=None, start_timestamp=None):
-        klass._foundations_context.job_id = job_name
-        klass._foundations_context.user_name = user
-        QueueJob(klass._message_router, klass._foundations_context).push_message()
+        klass._foundations_job.job_id = job_name
+        klass._foundations_job.user_name = user
+        QueueJob(klass._message_router, klass._foundations_job).push_message()
         klass._fake_start_time(start_timestamp)
-        RunJob(klass._message_router, klass._foundations_context).push_message()
+        RunJob(klass._message_router, klass._foundations_job).push_message()
         klass._set_tags(job_name, tags)
         klass._restore_time(start_timestamp, None)
 
     @classmethod
     def _make_queued_job(klass, job_name, user):
-        klass._foundations_context.job_id = job_name
-        klass._foundations_context.provenance.user_name = user
-        QueueJob(klass._message_router, klass._foundations_context).push_message()
+        klass._foundations_job.job_id = job_name
+        klass._foundations_job.provenance.user_name = user
+        QueueJob(klass._message_router, klass._foundations_job).push_message()
 
     @classmethod
     def _set_tags(klass, job_name, tags):
         from foundations_contrib.global_state import current_foundations_job
         from foundations import set_tag
 
-        foudnations_context = current_foundations_job()
-        foudnations_context.job_id = job_name
+        foundations_job = current_foundations_job()
+        foundations_job.job_id = job_name
 
         if tags is not None:
             for key, value in tags.items():
                 set_tag(key, value)
 
-        foundations_context.job_id = None
+        foundations_job.job_id = None

--- a/atlas/foundations_rest_api/src/acceptance/v2beta/test_artifact_loading.py
+++ b/atlas/foundations_rest_api/src/acceptance/v2beta/test_artifact_loading.py
@@ -16,7 +16,7 @@ class TestArtifactLoading(JobsTestsHelperMixinV2, APIAcceptanceTestCaseBase):
         import shutil
         
         import foundations_contrib.global_state as global_state
-        from foundations_internal.foundations_context import FoundationsContext
+        from foundations_internal.foundations_job import FoundationsJob
 
         shutil.rmtree('/tmp/foundations_acceptance', ignore_errors=True)
 
@@ -33,11 +33,11 @@ class TestArtifactLoading(JobsTestsHelperMixinV2, APIAcceptanceTestCaseBase):
         klass._make_completed_job(klass._some_artifacts, random_uuid, start_timestamp=100000001, end_timestamp=100086400)
 
         klass._old_config = deepcopy(global_state.config_manager.config())
-        klass._old_context = global_state.foundations_context
+        klass._old_context = global_state.foundations_job
 
         global_state.config_manager.reset()
 
-        global_state.foundations_context = FoundationsContext()
+        global_state.foundations_job = FoundationsJob()
 
         klass._save_artifacts()
 
@@ -48,13 +48,13 @@ class TestArtifactLoading(JobsTestsHelperMixinV2, APIAcceptanceTestCaseBase):
         global_state.config_manager.reset()
         global_state.config_manager.config().update(klass._old_config)
 
-        global_state.foundations_context = klass._old_context
+        global_state.foundations_job = klass._old_context
 
     @classmethod
     def _set_job_id(klass, job_id):
         import foundations_contrib.global_state as global_state
 
-        context = global_state.foundations_context
+        context = global_state.foundations_job
         context.job_id = job_id
 
     @classmethod

--- a/atlas/foundations_rest_api/src/acceptance/v2beta/test_artifact_loading.py
+++ b/atlas/foundations_rest_api/src/acceptance/v2beta/test_artifact_loading.py
@@ -54,8 +54,8 @@ class TestArtifactLoading(JobsTestsHelperMixinV2, APIAcceptanceTestCaseBase):
     def _set_job_id(klass, job_id):
         import foundations_contrib.global_state as global_state
 
-        context = global_state.foundations_job
-        context.job_id = job_id
+        job = global_state.foundations_job
+        job.job_id = job_id
 
     @classmethod
     def _artifact_fixture_path(klass, artifact_name):

--- a/atlas/foundations_rest_api/src/test/v2beta/models/test_job_listing.py
+++ b/atlas/foundations_rest_api/src/test/v2beta/models/test_job_listing.py
@@ -22,9 +22,9 @@ class TestJobListingV2(Spec):
     @set_up
     def set_up(self):
         import fakeredis
-        from foundations_internal.foundations_context import FoundationsContext
+        from foundations_internal.foundations_job import FoundationsJob
 
-        self._context = FoundationsContext()
+        self._context = FoundationsJob()
         self.patch('foundations_rest_api.global_state.redis_connection', fakeredis.FakeRedis())
 
     def test_has_job_id(self):

--- a/atlas/foundations_sdk/src/foundations/artifacts/__init__.py
+++ b/atlas/foundations_sdk/src/foundations/artifacts/__init__.py
@@ -2,14 +2,14 @@
 
 def create_syncable_directory(key, directory_path=None, source_job_id=None):
     from foundations.artifacts.syncable_directory import SyncableDirectory
-    from foundations_contrib.global_state import current_foundations_context
+    from foundations_contrib.global_state import current_foundations_job
     from tempfile import mkdtemp
     
     if directory_path is None:
         directory_path = mkdtemp()
 
     try:
-        job_id = current_foundations_context().job_id
+        job_id = current_foundations_job().job_id
     except ValueError:
         job_id = None
     return SyncableDirectory(key, directory_path, job_id, source_job_id or job_id)

--- a/atlas/foundations_sdk/src/foundations/job_metrics/__init__.py
+++ b/atlas/foundations_sdk/src/foundations/job_metrics/__init__.py
@@ -24,11 +24,11 @@ def _log_metric(key, value):
 
 
 def _log_metric_in_running_job(key, value):
-    from foundations_contrib.global_state import message_router, current_foundations_context
+    from foundations_contrib.global_state import message_router, current_foundations_job
     from foundations_events.producers.metric_logged import MetricLogged
 
-    project_name = current_foundations_context().project_name
-    job_id = current_foundations_context().job_id
+    project_name = current_foundations_job().project_name
+    job_id = current_foundations_job().job_id
 
     metric_logged_producer = MetricLogged(message_router, project_name, job_id, key, value)
     metric_logged_producer.push_message()

--- a/atlas/foundations_sdk/src/foundations/job_parameters/__init__.py
+++ b/atlas/foundations_sdk/src/foundations/job_parameters/__init__.py
@@ -29,10 +29,10 @@ def log_param(key, value):
     log_warning_if_not_running_in_job(_log_param_in_running_job, key, value)
 
 def _log_param_in_running_job(key, value):
-    from foundations_contrib.global_state import current_foundations_context, redis_connection
+    from foundations_contrib.global_state import current_foundations_job, redis_connection
 
-    project_name = current_foundations_context().project_name
-    job_id = current_foundations_context().job_id
+    project_name = current_foundations_job().project_name
+    job_id = current_foundations_job().job_id
 
     _insert_parameter_name_into_projects_params_set(redis_connection, project_name, key)
     _insert_input_parameter_name_into_projects_input_params_set(redis_connection, project_name, key)

--- a/atlas/foundations_sdk/src/foundations/local_run/__init__.py
+++ b/atlas/foundations_sdk/src/foundations/local_run/__init__.py
@@ -56,12 +56,12 @@ def set_up_job_environment():
         f"{yaml.dump(config_manager.config(), default_flow_style=False)}"
     )
 
-    foundations_context = current_foundations_job()
+    foundations_job = current_foundations_job()
     
-    _set_job_state(foundations_context)
+    _set_job_state(foundations_job)
 
-    QueueJob(message_router, foundations_context).push_message()
-    RunJob(message_router, foundations_context).push_message()
+    QueueJob(message_router, foundations_job).push_message()
+    RunJob(message_router, foundations_job).push_message()
 
     atexit.register(_at_exit_callback)
     _set_up_exception_handling()
@@ -106,6 +106,7 @@ def _at_exit_callback():
 
     global _exception_happened
 
+    upload_artifacts(current_foundations_job().job_id)
     # This try-except block should be refactored at a later date
 
     if _exception_happened:
@@ -118,12 +119,12 @@ def _at_exit_callback():
         CompleteJob(message_router, current_foundations_job()).push_message()
 
 
-def _set_job_state(foundations_context):
+def _set_job_state(foundations_job):
     from uuid import uuid4
     import os
 
-    foundations_context.job_id = os.environ.get("FOUNDATIONS_JOB_ID", str(uuid4()))
-    foundations_context.project_name = os.environ.get("FOUNDATIONS_PROJECT_NAME",
+    foundations_job.job_id = os.environ.get("FOUNDATIONS_JOB_ID", str(uuid4()))
+    foundations_job.project_name = os.environ.get("FOUNDATIONS_PROJECT_NAME",
                                                       os.environ.get("PROJECT_NAME", _default_project_name()))
 
 

--- a/atlas/foundations_sdk/src/foundations/local_run/__init__.py
+++ b/atlas/foundations_sdk/src/foundations/local_run/__init__.py
@@ -44,7 +44,7 @@ def set_up_job_environment():
     from foundations_events.producers.jobs import QueueJob
     from foundations_events.producers.jobs import RunJob
     from foundations_contrib.global_state import (
-        current_foundations_context,
+        current_foundations_job,
         message_router,
         config_manager,
     )
@@ -56,7 +56,7 @@ def set_up_job_environment():
         f"{yaml.dump(config_manager.config(), default_flow_style=False)}"
     )
 
-    foundations_context = current_foundations_context()
+    foundations_context = current_foundations_job()
     
     _set_job_state(foundations_context)
 
@@ -97,7 +97,7 @@ def _handle_exception(exception_type, value, traceback):
 
 def _at_exit_callback():
     from foundations_contrib.global_state import (
-        current_foundations_context,
+        current_foundations_job,
         message_router,
     )
     from foundations_contrib.archiving.upload_artifacts import upload_artifacts
@@ -106,17 +106,16 @@ def _at_exit_callback():
 
     global _exception_happened
 
-    upload_artifacts(current_foundations_context().job_id)
     # This try-except block should be refactored at a later date
 
     if _exception_happened:
         FailedJob(
             message_router,
-            current_foundations_context(),
+            current_foundations_job(),
             {"type": Exception, "exception": "", "traceback": []},
         ).push_message()
     else:
-        CompleteJob(message_router, current_foundations_context()).push_message()
+        CompleteJob(message_router, current_foundations_job()).push_message()
 
 
 def _set_job_state(foundations_context):

--- a/atlas/foundations_sdk/src/foundations/projects.py
+++ b/atlas/foundations_sdk/src/foundations/projects.py
@@ -13,8 +13,8 @@ def set_project_name(project_name="default"):
     Raises:
         - This method doesn't raise any exceptions.
     """
-    from foundations.global_state import current_foundations_context
-    current_foundations_context().project_name = project_name
+    from foundations.global_state import current_foundations_job
+    current_foundations_job().project_name = project_name
 
 
 def _get_metrics_for_all_jobs(project_name):
@@ -99,10 +99,10 @@ def set_tag(key, value=''):
 
 
 def _set_tag_in_running_jobs(key, value):
-    from foundations_contrib.global_state import message_router, current_foundations_context
+    from foundations_contrib.global_state import message_router, current_foundations_job
     from foundations_events.producers.tag_set import TagSet
 
-    job_id = current_foundations_context().job_id
+    job_id = current_foundations_job().job_id
 
     tag_set_producer = TagSet(message_router, job_id, key, value)
     tag_set_producer.push_message()

--- a/atlas/foundations_sdk/src/foundations/utils.py
+++ b/atlas/foundations_sdk/src/foundations/utils.py
@@ -223,9 +223,9 @@ def datetime_string(time):
 
 
 def log_warning_if_not_running_in_job(function_if_running_in_job, *args):
-    from foundations_contrib.global_state import log_manager, current_foundations_context
+    from foundations_contrib.global_state import log_manager, current_foundations_job
 
-    if current_foundations_context().is_in_running_job():
+    if current_foundations_job().is_in_running_job():
         function_if_running_in_job(*args)
     elif not log_manager.foundations_not_running_warning_printed():
         logger = log_manager.get_logger(__name__)

--- a/atlas/foundations_sdk/src/integration/config.py
+++ b/atlas/foundations_sdk/src/integration/config.py
@@ -5,14 +5,14 @@ def _config():
     from os import getcwd
     from foundations_contrib.global_state import (
         config_manager,
-        current_foundations_context,
+        current_foundations_job,
     )
     from foundations_contrib.global_state import config_manager
     from foundations_contrib.local_file_system_pipeline_archive import LocalFileSystemPipelineArchive
     from foundations_contrib.local_file_system_pipeline_listing import LocalFileSystemPipelineListing
 
     # ensure a job uuid is set
-    current_foundations_context().job_id = "integration-test-job"
+    current_foundations_job().job_id = "integration-test-job"
 
     # separates test runs
     test_uuid = uuid4()

--- a/atlas/foundations_sdk/src/integration/test_log_param.py
+++ b/atlas/foundations_sdk/src/integration/test_log_param.py
@@ -76,5 +76,5 @@ class TestLogParam(Spec):
         self.assertEqual(flattened_parameters_data, loads(logged_parameters))
 
     def _set_job_id(self, job_id):
-        from foundations_contrib.global_state import current_foundations_context
-        current_foundations_context().job_id = job_id
+        from foundations_contrib.global_state import current_foundations_job
+        current_foundations_job().job_id = job_id

--- a/atlas/foundations_sdk/src/test/artifacts/test_syncable_directory.py
+++ b/atlas/foundations_sdk/src/test/artifacts/test_syncable_directory.py
@@ -233,18 +233,18 @@ class TestSyncableDirectory(Spec):
     def test_foundations_create_syncable_directory_defaults_to_current_job_for_remote_and_local(self):
         from foundations import create_syncable_directory
 
-        context = Mock()
-        context.job_id = self.local_job_id
-        self.patch('foundations_contrib.global_state.current_foundations_context').return_value = context
+        job = Mock()
+        job.job_id = self.local_job_id
+        self.patch('foundations_contrib.global_state.current_foundations_job').return_value = job
         instance = self._mock_syncable_directory(self.local_job_id)
         self.assertEqual(instance, create_syncable_directory(self.key, self.directory_path))
 
     def test_foundations_create_syncable_directory_uses_source_job_for_remote(self):
         from foundations import create_syncable_directory
 
-        context = Mock()
-        context.job_id = self.local_job_id
-        self.patch('foundations_contrib.global_state.current_foundations_context').return_value = context
+        job = Mock()
+        job.job_id = self.local_job_id
+        self.patch('foundations_contrib.global_state.current_foundations_job').return_value = job
 
         instance = self._mock_syncable_directory(self.remote_job_id)
         self.assertEqual(instance, create_syncable_directory(self.key, self.directory_path, self.remote_job_id))        

--- a/atlas/foundations_sdk/src/test/job_metrics/test_log_metric.py
+++ b/atlas/foundations_sdk/src/test/job_metrics/test_log_metric.py
@@ -70,13 +70,13 @@ class TestLogMetric(Spec):
         import os
         from foundations_contrib.global_state import message_router
 
-        foundations_context_function = self.patch('foundations_contrib.global_state.current_foundations_context')
+        foundations_job_function = self.patch('foundations_contrib.global_state.current_foundations_job')
 
-        self.foundations_context = Mock()
-        self.foundations_context.job_id = ValueError()
-        self.foundations_context.is_in_running_job.return_value = False
-        self.foundations_context.project_name = self.fake_project_name
-        foundations_context_function.return_value = self.foundations_context
+        self.foundations_job = Mock()
+        self.foundations_job.job_id = ValueError()
+        self.foundations_job.is_in_running_job.return_value = False
+        self.foundations_job.project_name = self.fake_project_name
+        foundations_job_function.return_value = self.foundations_job
 
         self._redis = self.patch('foundations_contrib.global_state.redis_connection', fakeredis.FakeRedis())
         self._message_router = message_router
@@ -95,8 +95,8 @@ class TestLogMetric(Spec):
         self._message_router.add_listener(SingleProjectMetric(self._redis), 'job_metrics')
 
     def _set_job_running(self):
-        self.foundations_context.job_id = self.fake_job_id
-        self.foundations_context.is_in_running_job.return_value = True
+        self.foundations_job.job_id = self.fake_job_id
+        self.foundations_job.is_in_running_job.return_value = True
 
     def _run_job_and_log_metric(self, metric_name, metric_value):
         self._set_job_running()

--- a/atlas/foundations_sdk/src/test/job_parameters/test_log_param.py
+++ b/atlas/foundations_sdk/src/test/job_parameters/test_log_param.py
@@ -51,18 +51,18 @@ class TestLogParam(Spec):
     def set_up(self):
         import fakeredis
 
-        foundations_context_function = self.patch('foundations_contrib.global_state.current_foundations_context')
+        foundations_job_function = self.patch('foundations_contrib.global_state.current_foundations_job')
 
-        self.foundations_context = Mock()
-        self.foundations_context.job_id = ValueError()
-        self.foundations_context.is_in_running_job.return_value = False
-        self.foundations_context.project_name.return_value = 'default'
-        foundations_context_function.return_value = self.foundations_context
+        self.foundations_job = Mock()
+        self.foundations_job.job_id = ValueError()
+        self.foundations_job.is_in_running_job.return_value = False
+        self.foundations_job.project_name.return_value = 'default'
+        foundations_job_function.return_value = self.foundations_job
 
         self.redis_connection = self.patch('foundations_contrib.global_state.redis_connection', fakeredis.FakeRedis())
 
     def test_log_param_inserts_parameter_key_into_input_params_keys_set(self):
-        self.foundations_context.project_name = self.project_name
+        self.foundations_job.project_name = self.project_name
         self._set_job_running()
         
         log_param(self.fake_key, self.fake_value)
@@ -71,7 +71,7 @@ class TestLogParam(Spec):
     def test_log_param_sets_input_parameter_data(self):
         from foundations_internal.foundations_serializer import loads
 
-        self.foundations_context.project_name = self.project_name
+        self.foundations_job.project_name = self.project_name
         self._set_job_running()
         
         log_param(self.fake_key, self.fake_value)
@@ -82,7 +82,7 @@ class TestLogParam(Spec):
     def test_log_param_sets_input_parameter_data_with_multiple_params(self):
         from foundations_internal.foundations_serializer import loads
 
-        self.foundations_context.project_name = self.project_name
+        self.foundations_job.project_name = self.project_name
         self._set_job_running()
         
         log_param(self.fake_key, self.fake_value)
@@ -96,7 +96,7 @@ class TestLogParam(Spec):
         self.assertEqual(expected_params, actual_params)
 
     def test_log_param_inserts_parameter_key_into_projects_params_keys_set(self):
-        self.foundations_context.project_name = self.project_name
+        self.foundations_job.project_name = self.project_name
         self._set_job_running()
         
         log_param(self.fake_key, self.fake_value)
@@ -105,7 +105,7 @@ class TestLogParam(Spec):
     def test_log_param_sets_job_run_data(self):
         import json
 
-        self.foundations_context.project_name = self.project_name
+        self.foundations_job.project_name = self.project_name
         self._set_job_running()
         
         log_param(self.fake_key, self.fake_value)
@@ -116,7 +116,7 @@ class TestLogParam(Spec):
     def test_log_param_sets_job_run_data_with_multiple_params(self):
         import json
 
-        self.foundations_context.project_name = self.project_name
+        self.foundations_job.project_name = self.project_name
         self._set_job_running()
         
         log_param(self.fake_key, self.fake_value)
@@ -130,5 +130,5 @@ class TestLogParam(Spec):
         self.assertEqual(expected_params, actual_params)
 
     def _set_job_running(self):
-        self.foundations_context.job_id = self.job_id
-        self.foundations_context.is_in_running_job.return_value = True
+        self.foundations_job.job_id = self.job_id
+        self.foundations_job.is_in_running_job.return_value = True

--- a/atlas/foundations_sdk/src/test/local_run/test_set_default_environment.py
+++ b/atlas/foundations_sdk/src/test/local_run/test_set_default_environment.py
@@ -76,11 +76,11 @@ class TestSetDefaultEnvironment(Spec):
         return self.faker.uuid4()
 
     @let_now
-    def foundations_context(self):
+    def foundations_job(self):
         from foundations_internal.foundations_job import FoundationsJob
 
-        context = FoundationsJob()
-        return self.patch('foundations_contrib.global_state.foundations_context', context)
+        job = FoundationsJob()
+        return self.patch('foundations_contrib.global_state.foundations_job', job)
 
     mock_config_listing_klass = let_patch_mock_with_conditional_return('foundations_core_cli.typed_config_listing.TypedConfigListing')
 
@@ -100,9 +100,9 @@ class TestSetDefaultEnvironment(Spec):
         self.message = None
         self.at_exit = None
 
-        self.mock_run_job_klass.return_when(self.mock_run_job, self.mock_message_router, self.foundations_context)
-        self.mock_complete_job_klass.return_when(self.mock_complete_job, self.mock_message_router, self.foundations_context)
-        self.mock_failed_job_klass.return_when(self.mock_failed_job, self.mock_message_router, self.foundations_context, self.exception_data)
+        self.mock_run_job_klass.return_when(self.mock_run_job, self.mock_message_router, self.foundations_job)
+        self.mock_complete_job_klass.return_when(self.mock_complete_job, self.mock_message_router, self.foundations_job)
+        self.mock_failed_job_klass.return_when(self.mock_failed_job, self.mock_message_router, self.foundations_job, self.exception_data)
 
         self.mock_config_listing_klass.return_when(self.mock_config_listing, 'execution')
 
@@ -161,12 +161,12 @@ class TestSetDefaultEnvironment(Spec):
 
     def test_sets_default_job_id(self):
         set_up_job_environment()
-        self.assertEqual(self.random_uuid, self.foundations_context.job_id)
+        self.assertEqual(self.random_uuid, self.foundations_job.job_id)
 
     def test_sets_override_job_id(self):
         self.mock_os_environment['FOUNDATIONS_JOB_ID'] = self.override_job_id
         set_up_job_environment()
-        self.assertEqual(self.override_job_id, self.foundations_context.job_id)
+        self.assertEqual(self.override_job_id, self.foundations_job.job_id)
 
     def test_pushes_queued_job_message_with_project_name_set(self):
         set_up_job_environment()

--- a/atlas/foundations_sdk/src/test/local_run/test_set_default_environment.py
+++ b/atlas/foundations_sdk/src/test/local_run/test_set_default_environment.py
@@ -77,9 +77,9 @@ class TestSetDefaultEnvironment(Spec):
 
     @let_now
     def foundations_context(self):
-        from foundations_internal.foundations_context import FoundationsContext
+        from foundations_internal.foundations_job import FoundationsJob
 
-        context = FoundationsContext()
+        context = FoundationsJob()
         return self.patch('foundations_contrib.global_state.foundations_context', context)
 
     mock_config_listing_klass = let_patch_mock_with_conditional_return('foundations_core_cli.typed_config_listing.TypedConfigListing')

--- a/atlas/foundations_sdk/src/test/test_projects.py
+++ b/atlas/foundations_sdk/src/test/test_projects.py
@@ -13,8 +13,8 @@ from foundations import set_tag
 
 
 class TestProjects(Spec):
-    foundations_context = let_patch_instance(
-        "foundations_contrib.global_state.current_foundations_context"
+    foundations_job = let_patch_instance(
+        "foundations_contrib.global_state.current_foundations_job"
     )
     message_router = let_patch_mock("foundations_contrib.global_state.message_router")
 
@@ -111,10 +111,10 @@ class TestProjects(Spec):
 
     @set_up
     def set_up(self):
-        self.foundations_context.job_id = None
-        self.foundations_context.project_name = self.project_name
+        self.foundations_job.job_id = None
+        self.foundations_job.project_name = self.project_name
 
-        self.foundations_context.provenance.annotations = (
+        self.foundations_job.provenance.annotations = (
             self.provenance_annotations
         )
         self.redis.flushall()
@@ -123,14 +123,14 @@ class TestProjects(Spec):
         set_project_name(self.project_name)
         self.assertEqual(
             self.project_name,
-            self.foundations_context.project_name,
+            self.foundations_job.project_name,
         )
 
     def test_set_project_name_sets_project_name_different_name(self):
         set_project_name(self.project_name)
         self.assertEqual(
             self.project_name,
-            self.foundations_context.project_name,
+            self.foundations_job.project_name,
         )
 
     def test_set_project_name_is_global(self):
@@ -139,7 +139,7 @@ class TestProjects(Spec):
         foundations.set_project_name(self.project_name)
         self.assertEqual(
             self.project_name,
-            self.foundations_context.project_name,
+            self.foundations_job.project_name,
         )
 
     def test_set_project_name_is_global(self):
@@ -148,7 +148,7 @@ class TestProjects(Spec):
         foundations.set_project_name(self.project_name)
         self.assertEqual(
             self.project_name,
-            self.foundations_context.project_name,
+            self.foundations_job.project_name,
         )
 
     @patch("foundations_contrib.models.project_listing.ProjectListing.find_project")
@@ -405,7 +405,7 @@ class TestProjects(Spec):
         assert_frame_equal(expected_data_frame, job_annotations)
 
     def test_set_tag_when_in_job_sets_tag(self):
-        self.foundations_context.job_id = self.job_id
+        self.foundations_job.job_id = self.job_id
         set_tag(self.random_tag, self.random_tag_value)
         self.message_router.push_message.assert_called_with(
             "job_tag",

--- a/atlas/foundations_sdk/src/test/test_utils.py
+++ b/atlas/foundations_sdk/src/test/test_utils.py
@@ -14,14 +14,14 @@ class TestUtils(Spec):
 
     @set_up
     def set_up(self):
-        self.foundations_context_function = self.patch('foundations_contrib.global_state.current_foundations_context')
+        self.foundations_job_function = self.patch('foundations_contrib.global_state.current_foundations_job')
 
-        self.foundations_context = Mock()
-        self.foundations_context.job_id.side_effect = ValueError()
-        self.foundations_context.is_in_running_job.return_value = False
-        self.foundations_context.project_name.return_value = 'some_name'
+        self.foundations_job = Mock()
+        self.foundations_job.job_id.side_effect = ValueError()
+        self.foundations_job.is_in_running_job.return_value = False
+        self.foundations_job.project_name.return_value = 'some_name'
 
-        self.foundations_context_function.return_value = self.foundations_context
+        self.foundations_job_function.return_value = self.foundations_job
 
     @tear_down
     def tear_down(self):
@@ -127,14 +127,14 @@ class TestUtils(Spec):
     def test_log_warning_if_not_running_in_job_does_not_show_warning_if_in_running_job(self):
         from foundations.utils import log_warning_if_not_running_in_job
 
-        self.foundations_context.is_in_running_job.return_value = True
+        self.foundations_job.is_in_running_job.return_value = True
         log_warning_if_not_running_in_job(_some_function, {'result': False})
         self.mock_logger.warning.assert_not_called()
 
     def test_log_warning_if_not_running_in_job_runs_function_if_in_running_job(self):
         from foundations.utils import log_warning_if_not_running_in_job
 
-        self.foundations_context.is_in_running_job.return_value = True
+        self.foundations_job.is_in_running_job.return_value = True
         some_dict = {'result': False}
         log_warning_if_not_running_in_job(_some_function, some_dict)
         self.assertTrue(some_dict['result'])
@@ -142,7 +142,7 @@ class TestUtils(Spec):
     def test_log_warning_if_not_running_in_job_does_not_run_function_if_not_in_job(self):
         from foundations.utils import log_warning_if_not_running_in_job
 
-        self.foundations_context.is_in_running_job.return_value = False
+        self.foundations_job.is_in_running_job.return_value = False
         some_dict = {'result': False}
         log_warning_if_not_running_in_job(_some_function, some_dict)
         self.assertFalse(some_dict['result'])

--- a/atlas/gcp_utils/src/integration/test_deploy_job.py
+++ b/atlas/gcp_utils/src/integration/test_deploy_job.py
@@ -9,7 +9,7 @@ class TestDeployJob(unittest.TestCase):
         cleanup()
 
     def test_can_deploy_job_remotely(self):
-        from foundations.global_state import foundations_context
+        from foundations.global_state import foundations_job
         from os.path import isfile
         from integration.config import make_code_bucket
         from foundations_gcp import GCPBucket
@@ -17,7 +17,7 @@ class TestDeployJob(unittest.TestCase):
         def method():
             pass
 
-        stage = foundations_context.pipeline().stage(method)
+        stage = foundations_job.pipeline().stage(method)
         deployment = self._make_deployment(stage)
         deployment.deploy()
 

--- a/atlas/testing/acceptance/fixtures/deployable_script_parameters/project_code/script_to_run.py
+++ b/atlas/testing/acceptance/fixtures/deployable_script_parameters/project_code/script_to_run.py
@@ -2,8 +2,8 @@
 import foundations
 import json
 
-from foundations_contrib.global_state import current_foundations_context
+from foundations_contrib.global_state import current_foundations_job
 
 params = foundations.load_parameters()
-print(current_foundations_context().job_id)
+print(current_foundations_job().job_id)
 print(json.dumps(params))

--- a/atlas/testing/acceptance/fixtures/deployable_script_parameters_empty_params/project_code/script_to_run.py
+++ b/atlas/testing/acceptance/fixtures/deployable_script_parameters_empty_params/project_code/script_to_run.py
@@ -2,8 +2,8 @@
 import foundations
 import json
 
-from foundations_contrib.global_state import current_foundations_context
+from foundations_contrib.global_state import current_foundations_job
 
 params = foundations.load_parameters()
-print(current_foundations_context().job_id)
+print(current_foundations_job().job_id)
 print(json.dumps(params))

--- a/atlas/testing/acceptance/fixtures/deployable_script_parameters_no_parameters/project_code/script_to_run.py
+++ b/atlas/testing/acceptance/fixtures/deployable_script_parameters_no_parameters/project_code/script_to_run.py
@@ -2,8 +2,8 @@
 import foundations
 import json
 
-from foundations_contrib.global_state import current_foundations_context
+from foundations_contrib.global_state import current_foundations_job
 
 params = foundations.load_parameters()
-print(current_foundations_context().job_id)
+print(current_foundations_job().job_id)
 print(json.dumps(params))

--- a/atlas/testing/acceptance/fixtures/in_job_log_metric_script.py
+++ b/atlas/testing/acceptance/fixtures/in_job_log_metric_script.py
@@ -2,15 +2,15 @@
 import os
 
 import foundations
-from foundations_contrib.global_state import current_foundations_context, message_router
+from foundations_contrib.global_state import current_foundations_job, message_router
 from foundations_events.producers.jobs import RunJob
 
 foundations.set_project_name('default')
 
 job_id = os.environ['ACCEPTANCE_TEST_JOB_ID']
-current_foundations_context().job_id = job_id
+current_foundations_job().job_id = job_id
 
-RunJob(message_router, current_foundations_context()).push_message()
+RunJob(message_router, current_foundations_job()).push_message()
 
 foundations.log_metric('key', 'value')
 print('Hello World!')

--- a/atlas/testing/acceptance/fixtures/in_job_set_annotation_script.py
+++ b/atlas/testing/acceptance/fixtures/in_job_set_annotation_script.py
@@ -2,15 +2,15 @@
 import os
 
 import foundations
-from foundations_contrib.global_state import current_foundations_context, message_router
+from foundations_contrib.global_state import current_foundations_job, message_router
 from foundations_events.producers.jobs import RunJob
 
 foundations.set_project_name('default')
 
 job_id = os.environ['ACCEPTANCE_TEST_JOB_ID']
-current_foundations_context().job_id = job_id
+current_foundations_job().job_id = job_id
 
-RunJob(message_router, current_foundations_context()).push_message()
+RunJob(message_router, current_foundations_job()).push_message()
 
 foundations.set_tag('model type', 'simple mlp')
 foundations.set_tag('data set', 'out of time')

--- a/atlas/testing/acceptance/fixtures/job_data_production/success.py
+++ b/atlas/testing/acceptance/fixtures/job_data_production/success.py
@@ -1,5 +1,5 @@
 from foundations import log_metric
-from foundations.global_state import redis_connection, current_foundations_context
+from foundations.global_state import redis_connection, current_foundations_job
 
 log_metric('hello', 1)
 log_metric('hello', 2)

--- a/atlas/testing/acceptance/fixtures/run_locally/main.py
+++ b/atlas/testing/acceptance/fixtures/run_locally/main.py
@@ -1,5 +1,5 @@
 import foundations
-from foundations_contrib.global_state import current_foundations_context, redis_connection
+from foundations_contrib.global_state import current_foundations_job, redis_connection
 
 foundations.log_metric('ugh', 10)
 
@@ -9,4 +9,4 @@ with open('thomas_text.txt', 'w') as f:
 foundations.save_artifact('thomas_text.txt', 'just_some_artifact')
 foundations.log_param('blah', 20)
 
-redis_connection.set('foundations_testing_job_id', current_foundations_context().job_id)
+redis_connection.set('foundations_testing_job_id', current_foundations_job().job_id)

--- a/atlas/testing/acceptance/test_annotate_without_stage.py
+++ b/atlas/testing/acceptance/test_annotate_without_stage.py
@@ -18,15 +18,15 @@ class TestAnnotateWithoutStage(Spec, MetricsFetcher):
     def set_up(self):
         from uuid import uuid4
         from foundations_events.producers.jobs import QueueJob
-        from foundations_contrib.global_state import message_router, current_foundations_context
+        from foundations_contrib.global_state import message_router, current_foundations_job
         from acceptance.cleanup import cleanup
 
         cleanup()
 
         foundations.set_project_name('default')
         self._job_id = str(uuid4())
-        current_foundations_context().job_id = self._job_id
-        queue_job = QueueJob(message_router, current_foundations_context())
+        current_foundations_job().job_id = self._job_id
+        queue_job = QueueJob(message_router, current_foundations_job())
         queue_job.push_message()
 
     def test_set_tag_outside_of_job_throws_warning_and_does_not_set_tag_but_still_executes(self):

--- a/atlas/testing/acceptance/test_cli_init.py
+++ b/atlas/testing/acceptance/test_cli_init.py
@@ -47,8 +47,8 @@ class TestCLIInit(Spec, RunLocalJob):
         self.redis.delete('foundations_testing_job_id')
         with open('test-cli-init/main.py', 'a') as file:
             file.write(
-                '\nfrom foundations_contrib.global_state import redis_connection, current_foundations_context\n'
-                'redis_connection.set("foundations_testing_job_id", current_foundations_context().job_id)\n'
+                '\nfrom foundations_contrib.global_state import redis_connection, current_foundations_job\n'
+                'redis_connection.set("foundations_testing_job_id", current_foundations_job().job_id)\n'
             )
         
     def _assert_job_file_exists(self, job_id, relative_path):

--- a/atlas/testing/acceptance/test_log_metric_outside_stage.py
+++ b/atlas/testing/acceptance/test_log_metric_outside_stage.py
@@ -17,12 +17,12 @@ class TestLogMetricOutsideStage(Spec, MetricsFetcher):
     def set_up(self):
         from uuid import uuid4
         from foundations_events.producers.jobs import QueueJob
-        from foundations_contrib.global_state import message_router, current_foundations_context
+        from foundations_contrib.global_state import message_router, current_foundations_job
 
         foundations.set_project_name('default')
         self._job_id = str(uuid4())
-        current_foundations_context().job_id = self._job_id
-        queue_job = QueueJob(message_router, current_foundations_context())
+        current_foundations_job().job_id = self._job_id
+        queue_job = QueueJob(message_router, current_foundations_job())
         queue_job.push_message()
 
     def test_log_metric_outside_of_job_throws_warning_and_does_not_log_metric_but_still_executes(self):

--- a/atlas/testing/acceptance/test_stageless_caching.py
+++ b/atlas/testing/acceptance/test_stageless_caching.py
@@ -1,7 +1,7 @@
 
 from foundations_spec import *
 import foundations
-from foundations_contrib.global_state import current_foundations_context
+from foundations_contrib.global_state import current_foundations_job
 
 class TestStagelessCaching(Spec):
 
@@ -10,11 +10,11 @@ class TestStagelessCaching(Spec):
         from acceptance.cleanup import cleanup
 
         cleanup()
-        current_foundations_context().job_id = self.faker.uuid4()
+        current_foundations_job().job_id = self.faker.uuid4()
 
     @tear_down
     def tear_down(self):
-        current_foundations_context().job_id = None
+        current_foundations_job().job_id = None
 
     def test_function_value_is_cached_with_caching_enabled(self):
         @foundations.cache

--- a/atlas/testing/common/cleanup.py
+++ b/atlas/testing/common/cleanup.py
@@ -15,4 +15,4 @@ def cleanup():
     for file in glob('*.tgz'):
         remove(file)
 
-    foundations_contrib.global_state.foundations_context = FoundationsJob()
+    foundations_contrib.global_state.foundations_job = FoundationsJob()

--- a/atlas/testing/common/cleanup.py
+++ b/atlas/testing/common/cleanup.py
@@ -6,7 +6,7 @@ def cleanup():
     from os.path import isdir
     from glob import glob
     import foundations_contrib.global_state
-    from foundations_internal.foundations_context import FoundationsContext
+    from foundations_internal.foundations_job import FoundationsJob
 
     tmp_dir = getcwd() + '/foundations_home/job_data'
     if isdir(tmp_dir):
@@ -15,4 +15,4 @@ def cleanup():
     for file in glob('*.tgz'):
         remove(file)
 
-    foundations_contrib.global_state.foundations_context = FoundationsContext()
+    foundations_contrib.global_state.foundations_context = FoundationsJob()

--- a/atlas/testing/stageless_acceptance/fixtures/stageless_project/driver.py
+++ b/atlas/testing/stageless_acceptance/fixtures/stageless_project/driver.py
@@ -1,14 +1,14 @@
 
 import foundations
 from foundations import set_tag
-from foundations_contrib.global_state import current_foundations_context
+from foundations_contrib.global_state import current_foundations_job
 
 from model import *
 
 set_tag('model', 'cnn')
 
 def print_words():
-    print(f'Job \'{current_foundations_context().job_id}\' deployed')
+    print(f'Job \'{current_foundations_job().job_id}\' deployed')
     print('Hello World!')
 
 print_words()

--- a/atlas/testing/stageless_acceptance/fixtures/stageless_project_nested_project_code/project_code/driver.py
+++ b/atlas/testing/stageless_acceptance/fixtures/stageless_project_nested_project_code/project_code/driver.py
@@ -1,14 +1,14 @@
 
 import foundations
 from foundations import set_tag
-from foundations_contrib.global_state import current_foundations_context
+from foundations_contrib.global_state import current_foundations_job
 
 from model import *
 
 set_tag('model', 'cnn')
 
 def print_words():
-    print(f'Job \'{current_foundations_context().job_id}\' deployed')
+    print(f'Job \'{current_foundations_job().job_id}\' deployed')
     print('Hello World!')
 
 print_words()

--- a/tensorboard/acceptance/test_tensorboard_endpoints.py
+++ b/tensorboard/acceptance/test_tensorboard_endpoints.py
@@ -63,7 +63,7 @@ def cleanup():
     from os import getcwd, remove
     from os.path import isdir
     from glob import glob
-    from foundations_contrib.global_state import redis_connection, foundations_context
+    from foundations_contrib.global_state import redis_connection, foundations_job
     from foundations_internal.pipeline_context import PipelineContext
     from foundations_internal.pipeline import Pipeline
 
@@ -76,4 +76,4 @@ def cleanup():
 
     pipeline_context = PipelineContext()
     pipeline = Pipeline(pipeline_context)
-    foundations_context._pipeline = pipeline
+    foundations_job._pipeline = pipeline


### PR DESCRIPTION
Replacing all references to foundations_context to foundations_job for readability.

This is the last PR in the stack.