### PR TITLE
[Fix devenv startup - PART2] Add devenv start to github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,19 +16,14 @@ jobs:
   build:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: [3.6, 3.7, 3.8]
-    
-        # Steps represent a sequence of tasks that will be executed as part of the job
+    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Set up Python 3.7
       uses: actions/setup-python@v1
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: 3.7
 
     - name: Install requirements
       run: pip install -r requirements_test.txt
@@ -37,3 +32,7 @@ jobs:
       run: |
         . ./activate_dev_env.sh
         make unit-tests
+    - name: Start devenv
+      run: |
+        . ./activate_dev_env.sh
+        make devenv-start

--- a/devenv/configure.sh
+++ b/devenv/configure.sh
@@ -4,3 +4,7 @@ for file in $(find .foundations -type f -name "*.config"); do \
     envsubst < $file > $file.yaml
 done
 
+# .docker is missing in github actions runner
+if [ ! -d "$HOME/.docker" ]; then
+    mkdir $HOME/.docker
+fi

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -14,3 +14,4 @@ ifaddr==0.1.6
 twine==1.13.0
 awscli==1.16.297
 setuptools_scm==3.3.3
+docker-compose


### PR DESCRIPTION
Also reduce complexity a bit. I don't think we need multiple versions for testing.
That should be saved for testing the final product.