### PR TITLE
Removes 'nvidia' runtime parameter when Docker version is >= 19.03 (n…

### DIFF
--- a/atlas_server/src/atlas-server/__main__.py
+++ b/atlas_server/src/atlas-server/__main__.py
@@ -9,6 +9,7 @@ import requests
 from threading import Thread
 from time import sleep
 from urllib.parse import urlparse
+from pkg_resources import parse_version
 
 import docker
 import yaml
@@ -416,7 +417,7 @@ class CLI:
                 'mem_limit': '300m'
             }
 
-        if args.enable_gpu:
+        if args.enable_gpu and parse_version(self._client.version()['Version']) < parse_version('19.03'):
             scheduler_spec['runtime'] = 'nvidia'
 
         specs.append(scheduler_spec)


### PR DESCRIPTION
With the release of Docker 19.03 there is no longer the need to install nvidia-docker2 to access GPU's. When `atlas-server start -g` is called, it appends the 'nvidia' runtime flag which no longer is required nor exists and causes the scheduler to fail to start. This patch only add's the runtime flag if gpu is requested, and docker is <= 19.03