### PR TITLE
Change h2 files install location

### DIFF
--- a/atlas_installer/atlas_installer.py
+++ b/atlas_installer/atlas_installer.py
@@ -285,7 +285,7 @@ def dump_all_config_files(advanced, use_specified_version):
     DATABASE_CONFIG_PATH = FOUNDATIONS_HOME / 'config' / 'local_docker_scheduler' / 'database.config.yaml'
     SERVICE_CONFIG_PATH = FOUNDATIONS_HOME / 'config' / 'atlas.config.yaml'
     AUTH_PROXY_CONFIG_PATH = FOUNDATIONS_CONFIG_PATH / 'auth_proxy' / 'atlas'
-    AUTH_SERVER_DB_PATH = FOUNDATIONS_HOME / 'database' / 'h2'
+    AUTH_SERVER_DB_PATH = FOUNDATIONS_HOME / 'h2'
 
     # === Standard Configuration dictionaries
 

--- a/atlas_server/src/atlas-server/__main__.py
+++ b/atlas_server/src/atlas-server/__main__.py
@@ -453,9 +453,9 @@ class CLI:
                     'environment': ["KEYCLOAK_LOGLEVEL=DEBUG"],
                     'ports': {8080: args.auth_server_port, 8443: 8443},
                     'volumes': {
-                        convert_win_path_to_posix(Path(self._config['persistent_storage'] + '/h2/data')) 
+                        convert_win_path_to_posix(Path(self._foundations_home / 'h2/data')) 
                         if is_windows() 
-                        else self._config['persistent_storage'] + '/h2/data': {
+                        else self._foundations_home / 'h2/data': {
                             'bind': '/opt/jboss/keycloak/standalone/data', 'mode': 'rw'
                             },
                         },

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -14,4 +14,4 @@ ifaddr==0.1.6
 twine==1.13.0
 awscli==1.16.297
 setuptools_scm==3.3.3
-docker-compose
+docker-compose==1.25.5


### PR DESCRIPTION
Because the database folder in foundations home does not allow users to access it (is this what we intended?) I have to install the h2 files somewhere else. I think this is all that is needed to be changed since the other updates were on the build side. Could not fully verify due to the difficulty of trying to build locally. It's simpler to just see what happens in the pipeline.