### PR TITLE
Pin setuptools version to last major release in rest api Dockerfile

### DIFF
--- a/atlas/foundations_rest_api/Dockerfile
+++ b/atlas/foundations_rest_api/Dockerfile
@@ -13,7 +13,7 @@ RUN mkdir -p /var/foundations ~/.ssh
 WORKDIR /var/foundations
 
 RUN apk add --update --no-cache alpine-sdk python-dev libressl-dev libffi-dev linux-headers
-RUN pip install -U pip setuptools wheel
+RUN pip install -U pip setuptools==46.4.0 wheel
 COPY ./tmp/pip_wheels /var/foundations/
 
 RUN find -iname "foundations_internal-*.whl" | xargs pip install \


### PR DESCRIPTION
I started to see this error in the atlas rest api logs:

```
/usr/local/lib/python3.6/site-packages/pkg_resources/py2_warn.py:15: UserWarning: Setuptools no longer works on Python 2
************************************************************
Encountered a version of Setuptools that no longer supports
this version of Python. Please head to
https://bit.ly/setuptools-py2-sunset for support.
***************************************************
```

I believe that it is being caused by the latest major release of setuptools from two weeks ago. This change simply pins the version. This should fix the issue.