### PR TITLE
pin PyYAML==5.1, boto3==1.9.89, awscli==1.16.263 in requirements files

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ dill==0.2.8.2
 google-api-python-client==1.7.3
 google-auth-httplib2==0.0.3
 google-cloud-storage==1.10.0
-PyYAML==5.1.2
+PyYAML==5.1
 freezegun==0.3.12
 flask-restful==0.3.7
 Flask==1.1.1
@@ -14,7 +14,7 @@ promise==2.2.1
 redis==3.3.11
 slackclient==1.3.0
 Werkzeug==0.16.0
-boto3==1.9.86
+boto3==1.9.89
 boto==2.49.0
 python-jose==3.0.1
 python-keycloak==0.17.6

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -12,6 +12,6 @@ mock==2.0.0
 Faker==1.0.0
 ifaddr==0.1.6
 twine==1.13.0
-awscli==1.16.297
+awscli==1.16.263
 setuptools_scm==3.3.3
 docker-compose==1.25.5


### PR DESCRIPTION
build is currently failing (e.g. https://github.com/dessa-oss/atlas/pull/180/checks?check_run_id=1714144888) due to conflicting `botocore` transitive dependencies:

```
    awscli 1.16.297 depends on botocore==1.13.33 # from requirements_dev.txt
    boto3 1.9.86 depends on botocore<1.13.0 and >=1.12.86 # from requirements.txt
```

this PR pins `PyYAML==5.1`, `boto3==1.9.89`, `awscli==1.16.263`, which are the smallest possible version changes for `requirements.txt` that fix this dependency issue as well as any others that come up

btw your jenkins instance is currently experiencing executor starvation (and may have been for a while)
<img width="305" alt="Screen Shot 2021-01-16 at 12 38 25 PM" src="https://user-images.githubusercontent.com/17733984/104818777-bc24d080-57f7-11eb-9745-4bdd8f728ee3.png">

todo before ready for review:
- [x] escape dependency hell